### PR TITLE
Hotfix: Added default value to discord_name in User.model.ts and migration.

### DIFF
--- a/server/migrations/20230311005359-add-fields-to-user.js
+++ b/server/migrations/20230311005359-add-fields-to-user.js
@@ -6,6 +6,7 @@ module.exports = {
     await queryInterface.addColumn("users", "discord_name", {
       type: Sequelize.STRING(100),
       allowNull: false,
+      defaultValue: "",
     });
     await queryInterface.addColumn("users", "bio", {
       type: Sequelize.STRING(1000),

--- a/server/models/User.model.ts
+++ b/server/models/User.model.ts
@@ -35,6 +35,7 @@ User.init({
   discord_name: {
     type: DataTypes.STRING(100),
     allowNull: false,
+    defaultValue: '',
   },
   bio: {
     type: DataTypes.STRING(1000),


### PR DESCRIPTION
# Description

Heroku build failed: ERROR: column "discord_name" of relation "users" contains null values
Added default value to discord_name in User.model.ts and migration.

## Testing

If Heroku build succeeds we're good.

## Type of change

Please remove all except for everything applicable, and then remove this line.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] Changes have new/updated automated tests
- [ ] Changes have been manually tested
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Docs have been updated if applicable
- [ ] Tests have been updated if applicable
