### PR TITLE
feat: add initial profile pages

### DIFF
--- a/client/lib/axios.ts
+++ b/client/lib/axios.ts
@@ -8,7 +8,7 @@ export const createAxiosInstance = (req: IncomingMessage | null = null) => {
     baseURL: absoluteUrl(req).origin,
     withCredentials: true,
     headers: {
-      cookie: req.headers.cookie || '',
+      cookie: req?.headers.cookie || '',
     },
   });
 };

--- a/client/lib/axios.ts
+++ b/client/lib/axios.ts
@@ -4,10 +4,8 @@ import axios from 'axios';
 import absoluteUrl from 'next-absolute-url';
 
 export const createAxiosInstance = (req: IncomingMessage | null = null) => {
-  const origin = absoluteUrl(req).origin;
-
   return axios.create({
-    baseURL: origin,
+    baseURL: absoluteUrl(req).origin,
     withCredentials: true,
     headers: {
       cookie: req.headers.cookie || '',

--- a/client/lib/axios.ts
+++ b/client/lib/axios.ts
@@ -1,0 +1,18 @@
+import { IncomingMessage } from 'http';
+
+import axios from 'axios';
+import absoluteUrl from 'next-absolute-url';
+
+export const createAxiosInstance = (req: IncomingMessage | null = null) => {
+  const origin = absoluteUrl(req).origin;
+
+  return axios.create({
+    baseURL: origin,
+    withCredentials: true,
+    headers: {
+      cookie: req.headers.cookie || '',
+    },
+  });
+};
+
+export default createAxiosInstance;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -44,7 +44,7 @@ const Index: NextPage<Props> = (props) => {
 Index.getInitialProps = async ({ req }) => {
   try {
     const axios = createAxiosInstance(req);
-    await axios.get(`${origin}/api/users/`);
+    await axios.get('/api/users/');
 
     return { isAuthed: true };
   } catch (error) {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,8 @@
 import { Box, Button, Container, Typography } from '@mui/material';
-import axios, { RawAxiosRequestConfig } from 'axios';
 import { NextPage } from 'next';
-import absoluteUrl from 'next-absolute-url';
 import React from 'react';
 
+import createAxiosInstance from 'client/lib/axios';
 import { getDiscordOauthUrl } from 'client/lib/oauth';
 
 interface Props {
@@ -14,6 +13,7 @@ const Index: NextPage<Props> = (props) => {
   const [isAuthed, setIsAuthed] = React.useState(props.isAuthed);
 
   const onLogout = async () => {
+    const axios = createAxiosInstance();
     await axios.post('/api/auth/logout');
     setIsAuthed(false);
   };
@@ -42,18 +42,12 @@ const Index: NextPage<Props> = (props) => {
 };
 
 Index.getInitialProps = async ({ req }) => {
-  const { origin } = absoluteUrl(req);
   try {
-    const config: RawAxiosRequestConfig = req ? {
-      withCredentials: true,
-      headers: {
-        cookie: req.headers.cookie,
-      },
-    } : {};
-    await axios.get(`${origin}/api/users/`, config);
+    const axios = createAxiosInstance(req);
+    await axios.get(`${origin}/api/users/`);
+
     return { isAuthed: true };
-  } catch (err) {
-    // an error likely means a 401 was thrown
+  } catch (error) {
     return { isAuthed: false };
   }
 };

--- a/pages/profile/[id].tsx
+++ b/pages/profile/[id].tsx
@@ -16,10 +16,6 @@ type Props = {
 };
 
 const ProfilePage: NextPage<Props> = ({ user }: Props) => {
-  if (!user) {
-    return <div>User not found</div>;
-  }
-
   function possessiveForm(name: string): string {
     return name.endsWith('s') ? `${name}'` : `${name}'s`;
   }
@@ -112,7 +108,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async ({ req, query
 
     return { props: { user } };
   } catch (error) {
-    return { props: { notFound: true } };
+    return { notFound: true };
   }
 };
 

--- a/pages/profile/[id].tsx
+++ b/pages/profile/[id].tsx
@@ -98,7 +98,7 @@ const ProfilePage: NextPage<Props> = ({ user, statusCode }: Props) => {
   );
 };
 
-ProfilePage.getInitialProps = async ({ req, res, query }: NextPageContext): Promise<Props> => {
+ProfilePage.getInitialProps = async ({ req, res, query }: NextPageContext) => {
   const props: Props = {
     user: null,
     statusCode: 200,

--- a/pages/profile/[id].tsx
+++ b/pages/profile/[id].tsx
@@ -1,0 +1,119 @@
+import GitHubIcon from '@mui/icons-material/GitHub';
+import HomeRoundedIcon from '@mui/icons-material/HomeRounded';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import TwitterIcon from '@mui/icons-material/Twitter';
+import { Container, Box, ListItemIcon, ListItemButton, List, Typography } from '@mui/material';
+import axios, { RawAxiosRequestConfig } from 'axios';
+import { GetServerSideProps, NextPage } from 'next';
+import absoluteUrl from 'next-absolute-url';
+import React from 'react';
+
+import { UserProfile } from 'server/types/User';
+
+type Props = {
+  user?: UserProfile;
+  notFound?: boolean;
+};
+
+const ProfilePage: NextPage<Props> = ({ user }: Props) => {
+  if (!user) {
+    return <div>User not found</div>;
+  }
+
+  function possessiveForm(name: string): string {
+    return name.endsWith('s') ? `${name}'` : `${name}'s`;
+  }
+
+  return (
+    <>
+      <Container className="flex flex-col gap-4 pt-20 items-center">
+        <Box component="header">
+          <Typography variant="h1" className="text-5xl font-700 text-center">
+            {possessiveForm(user.discord_name)} Profile
+          </Typography>
+        </Box>
+
+        {user.bio && <Typography variant="body1" component="p">{user.bio}</Typography>}
+
+        <List className="flex gap-2">
+          {user.twitter_username && (
+            <ListItemButton
+              component="a"
+              href={`https://twitter.com/${user.twitter_username}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="p-2 rounded-full bg-gray-100 hover:bg-gray-200"
+            >
+              <ListItemIcon sx={{ minWidth: 'auto' }}>
+                <TwitterIcon className="text-gray-800"/>
+              </ListItemIcon>
+            </ListItemButton>
+          )}
+
+          {user.linkedin_url && (
+            <ListItemButton
+              component="a"
+              href={user.linkedin_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="p-2 rounded-full bg-gray-100 hover:bg-gray-200"
+            >
+              <ListItemIcon sx={{ minWidth: 'auto' }}>
+                <LinkedInIcon className="text-gray-800"/>
+              </ListItemIcon>
+            </ListItemButton>
+          )}
+
+          {user.github_username && (
+            <ListItemButton
+              component="a"
+              href={`https://github.com/${user.github_username}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="p-2 rounded-full bg-gray-100 hover:bg-gray-200"
+            >
+              <ListItemIcon sx={{ minWidth: 'auto' }}>
+                <GitHubIcon className="text-gray-800"/>
+              </ListItemIcon>
+            </ListItemButton>
+          )}
+
+          {user.website && (
+            <ListItemButton
+              component="a"
+              href={user.website}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="p-2 rounded-full bg-gray-100 hover:bg-gray-200"
+            >
+              <ListItemIcon sx={{ minWidth: 'auto' }}>
+                <HomeRoundedIcon className="text-gray-800"/>
+              </ListItemIcon>
+            </ListItemButton>
+          )}
+        </List>
+      </Container>
+    </>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps<Props> = async ({ req, query }) => {
+  const { origin } = absoluteUrl(req);
+
+  try {
+    const config: RawAxiosRequestConfig = req ? {
+      withCredentials: true,
+      headers: {
+        cookie: req.headers.cookie,
+      },
+    } : {};
+
+    const { data: user } = await axios.get<UserProfile>(`${origin}/api/users/${query.id}`, config);
+
+    return { props: { user } };
+  } catch (error) {
+    return { props: { notFound: true } };
+  }
+};
+
+export default ProfilePage;

--- a/pages/profile/[id].tsx
+++ b/pages/profile/[id].tsx
@@ -12,7 +12,6 @@ import { UserProfile } from 'server/types/User';
 
 type Props = {
   user?: UserProfile;
-  notFound?: boolean;
 };
 
 const ProfilePage: NextPage<Props> = ({ user }: Props) => {

--- a/pages/profile/[id].tsx
+++ b/pages/profile/[id].tsx
@@ -30,7 +30,7 @@ const ProfilePage: NextPage<Props> = ({ user, statusCode }: Props) => {
       <Container className="flex flex-col gap-4 pt-20 items-center">
         <Box component="header">
           <Typography variant="h1" className="text-5xl font-700 text-center">
-            {possessiveForm(user.discord_name || 'username')} Profile
+            {possessiveForm(user.discord_name)} Profile
           </Typography>
         </Box>
 

--- a/server/api/users/users.controller.ts
+++ b/server/api/users/users.controller.ts
@@ -3,6 +3,7 @@ import { NotFoundError } from 'express-response-errors';
 import _ from 'lodash';
 
 import { User } from 'server/models';
+import { UserProfile } from 'server/types/User';
 
 type ClientUser = Pick<User, 'id' | 'discord_user_id'>
 
@@ -16,15 +17,6 @@ export const getCurrentUser: RequestHandler<void, ClientUser>  = (req, res) => {
 
   res.json(filteredUser);
 };
-
-type UserProfile = Pick<User, 'id'
-| 'discord_user_id'
-| 'discord_name'
-| 'bio'
-| 'twitter_username'
-| 'linkedin_url'
-| 'github_username'
-| 'website'>
 
 export const getUserById: RequestHandler<{id: string}, UserProfile> = async (req, res) => {
   const user = await User.findByPk(req.params.id, {

--- a/server/types/User.ts
+++ b/server/types/User.ts
@@ -1,0 +1,10 @@
+import { User } from 'server/models';
+
+export type UserProfile = Pick<User, 'id'
+  | 'discord_user_id'
+  | 'discord_name'
+  | 'bio'
+  | 'twitter_username'
+  | 'linkedin_url'
+  | 'github_username'
+  | 'website'>;


### PR DESCRIPTION
Closes:
 - #11 

# Description

Creates a simple profile page that displays the user's Discord name, bio, and links to their social media accounts.

## Testing

Tests needed

## Type of change

Please remove all except for everything applicable, and then remove this line.

- New feature (non-breaking change which adds functionality)

## Screenshots

![image](https://user-images.githubusercontent.com/1634972/225718543-8e5b7577-edf1-4711-b7cc-6777b643a1da.png)

# Checklist:

- [ ] Changes have new/updated automated tests, if applicable
- [X] Changes have new/updated docs, if applicable
- [X] I have performed a self-review of my own code
- [X] I have added comments on any new, hard-to-understand code
- [X] Changes have been manually tested
- [X] Changes generate no new errors or warnings
