### PR TITLE
style: add additional style rules, organize eslintrc, & apply fixes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,6 +41,13 @@ module.exports = {
     'object-curly-spacing': ['error', 'always', { objectsInObjects: false }],
     'space-in-parens': ['error', 'never'],
 
+    // Newline padding rules
+    'padding-line-between-statements': [
+      'error',
+      { blankLine: 'always', prev: '*', next: 'export' },
+      { blankLine: 'any', prev: 'export', next: 'export' },
+    ],
+
     // Import rules
     'import/newline-after-import': 'error',
     'import/order': ['error', {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,46 +12,57 @@ module.exports = {
     node: true,
   },
   rules: {
-    semi: ['error', 'always'],
-    'no-trailing-spaces': 'error',
+    // Basic rules
     indent: ['error', 2, { SwitchCase: 1 }],
-    'comma-dangle': ['error', 'always-multiline'],
-    quotes: ['error', 'single'],
     'max-len': ['warn', 120],
     'prefer-const': 'error',
+    semi: ['error', 'always'],
+
+    // Quote rules
+    quotes: ['error', 'single'],
+    'quote-props': ['error', 'as-needed'],
+
+    // TypeScript rules
     '@typescript-eslint/no-explicit-any': 'error',
     '@typescript-eslint/no-unused-vars': 'error',
-    'quote-props': ['error', 'as-needed'],
-    'eol-last': ['error', 'always'],
+
+    // Comma rules
+    'comma-dangle': ['error', 'always-multiline'],
+    'comma-spacing': 'error',
     'comma-style': ['error', 'last'],
+
+    // End of file/trailing space rules
+    'eol-last': ['error', 'always'],
+    'no-multiple-empty-lines': ['error', { max: 1, maxEOF: 1 }],
+    'no-trailing-spaces': 'error',
+
+    // Brace/parenthesis spacing rules
     'array-bracket-spacing': ['error', 'never'],
     'object-curly-spacing': ['error', 'always', { objectsInObjects: false }],
     'space-in-parens': ['error', 'never'],
-    'import/order': [
-      'error',
-      {
-        groups: [
-          'builtin',
-          'external',
-          'internal',
-          'parent',
-          'sibling',
-          'index',
-          'object',
-        ],
-        'newlines-between': 'always',
-        alphabetize: { order: 'asc', caseInsensitive: true },
-      },
-    ],
+
+    // Import rules
+    'import/newline-after-import': 'error',
+    'import/order': ['error', {
+      groups: [
+        'builtin',
+        'external',
+        'internal',
+        'parent',
+        'sibling',
+        'index',
+        'object',
+      ],
+      'newlines-between': 'always',
+      alphabetize: { order: 'asc', caseInsensitive: true },
+    }],
   },
-  overrides: [
-    {
-      files: ['server/migrations/*.js'],
-      rules: {
-        '@typescript-eslint/no-unused-vars': 0,
-      },
+  overrides: [{
+    files: ['server/migrations/*.js'],
+    rules: {
+      '@typescript-eslint/no-unused-vars': 0,
     },
-  ],
+  }],
   settings: {
     'import/resolver': {
       typescript: true,
@@ -62,3 +73,4 @@ module.exports = {
     },
   },
 };
+

--- a/server/api/auth/index.ts
+++ b/server/api/auth/index.ts
@@ -1,6 +1,7 @@
 import { AsyncRouter } from 'express-async-router';
 
 import { login, logout } from './auth.controller';
+
 const authRouter = AsyncRouter();
 
 authRouter.post('/login', login);

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -6,7 +6,6 @@ import { User } from 'server/models';
 import { AnyRequestHandler } from 'server/types/express';
 import { AUTH_COOKIE_NAME } from 'shared/constants';
 
-
 export const attachUser: AnyRequestHandler = async (req, res, next) => {
   const token = req.cookies[AUTH_COOKIE_NAME];
   if (validateToken(token)) {

--- a/server/test/server.ts
+++ b/server/test/server.ts
@@ -11,8 +11,6 @@ import { Database } from 'server/lib/db';
 import { User } from 'server/models';
 import Server from 'server/server';
 
-
-
 const env = cleanEnv(process.env, {
   DB_NAME: str(),
   DB_USER: str(),


### PR DESCRIPTION
Closes N/A

# Description

Add some additional style rules, organize the eslintrc, & apply style fixes.

```js
// Ensure there is no space before and 1 space after commas.
// eg. [1, 2] not [1 ,2] or [1,2]
// https://eslint.org/docs/latest/rules/comma-spacing
'comma-spacing': 'error',

// Ensure there is only ever 1 consecutive empty line.
// https://eslint.org/docs/latest/rules/no-multiple-empty-lines
'no-multiple-empty-lines': ['error', { max: 1, maxEOF: 1 }],

// Ensure there is 1 empty line after the last import statement.
// https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/newline-after-import.md
'import/newline-after-import': 'error',

// Ensure there is 1 empty line above export statements.
// https://eslint.org/docs/latest/rules/padding-line-between-statements
'padding-line-between-statements': [
  'error',
  { blankLine: 'always', prev: '*', next: 'export' },
  { blankLine: 'any', prev: 'export', next: 'export' },
],
```

## Testing

N/A

## Type of change

Please remove all except for everything applicable, and then remove this line.

- Other (styles rules/fixes)

## Screenshots

N/A

# Checklist:

- [X] Changes have new/updated automated tests, if applicable
- [X] Changes have new/updated docs, if applicable
- [X] I have performed a self-review of my own code
- [X] I have added comments on any new, hard-to-understand code
- [X] Changes have been manually tested
- [X] Changes generate no new errors or warnings
