### PR TITLE
test: fix Jest issues

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,5 +1,6 @@
-/** @type {import('ts-jest').JestConfigWithTsJest} */
-module.exports = {
+import type { Config } from '@jest/types';
+
+const config: Config.InitialOptions = {
   preset: 'ts-jest',
   moduleDirectories: ['node_modules'],
   testEnvironment: 'node',
@@ -8,13 +9,7 @@ module.exports = {
     '**/?(*.)+(spec|test).+(ts|tsx|js)',
   ],
   transform: {
-    '^.+\\.(ts|tsx)$': 'ts-jest',
-  },
-  // this is deprecated but the suggested fix doesn't work :|
-  globals: {
-    'ts-jest': {
-      diagnostics: false,
-    },
+    '^.+\\.(ts|tsx)$': ['ts-jest', { diagnostics: false }],
   },
   moduleNameMapper: {
     '^server/(.*)': '<rootDir>/server/$1',
@@ -28,3 +23,5 @@ module.exports = {
     './cypress',
   ],
 };
+
+export default config;

--- a/server/test/server.ts
+++ b/server/test/server.ts
@@ -7,7 +7,7 @@ import { Sequelize } from 'sequelize';
 import supertest from 'supertest';
 import { Umzug, SequelizeStorage } from 'umzug';
 
-import { Database } from 'server/lib/db';
+import Db from 'server/lib/db';
 import { User } from 'server/models';
 import Server from 'server/server';
 
@@ -21,7 +21,7 @@ class TestServer extends Server {
   loggedInUser: User | null = null;
 
   async init() {
-    this.db = new Database(env.DB_NAME);
+    this.db = Db;
     this.umzug = new Umzug({
       migrations: {
         glob: ['../migrations/*.js', { cwd: __dirname }],
@@ -96,11 +96,7 @@ class TestServer extends Server {
   async destroy() {
     await this.revertMigrations();
     await this.db.sequelize.close();
-    if (this.server) {
-      return new Promise<void>((resolve) => {
-        this.server.close(() => resolve());
-      });
-    }
+    await this.server?.close();
   }
 }
 


### PR DESCRIPTION
Closes N/A

# Description

fix issue preventing Jest from exiting (open handle)
fix globals warning when running Jest
convert Jest config to TypeScript

## Testing

Run `npm run test:server`
Confirm that tests pass and that there isn't a `globals` warning before the tests execute
Confirm that there isn't an `open handle` warning after the tests execute.

## Type of change

Please remove all except for everything applicable, and then remove this line.

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

![image](https://user-images.githubusercontent.com/1634972/228403578-22bd81df-196b-4153-8d64-cf161b87536d.png)

# Checklist:

- [X] Changes have new/updated automated tests, if applicable
- [X] Changes have new/updated docs, if applicable
- [X] I have performed a self-review of my own code
- [X] I have added comments on any new, hard-to-understand code
- [X] Changes have been manually tested
- [X] Changes generate no new errors or warnings
