### PR TITLE
ci: add appropriate file extensions to linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,6 +42,7 @@ jobs:
         uses: wearerequired/lint-action@v2
         with:
           eslint: true
+          eslint_extensions: "js,jsx,ts,tsx"
 
       - name: Start Container
         run: docker-compose -f "docker-compose.test.yml" up -d

--- a/server/api/users/index.ts
+++ b/server/api/users/index.ts
@@ -5,7 +5,6 @@ import { requireSameId, sanitize } from 'server/middleware/users';
 
 import { getUserById, updateUserById } from './users.controller';
 
-
 const userRouter = AsyncRouter();
 
 userRouter.get('/:id', getUserById);


### PR DESCRIPTION
Closes N/A

# Description

The CI linter appears to only be linting `.js` files (see image below). This change should get it to check `js, jsx, ts, and tsx` file types.

## Testing

First commit had a linting error, the second commit fixed the styling and passed the checks; thus confirming that these changes have worked.

## Type of change

- Change to documentation/GitHub flows/CICD

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/1634972/228651454-6d1145d1-5aaa-4680-8bc9-bdf0d4a0a8e1.png)

After:
![image](https://user-images.githubusercontent.com/1634972/228654011-7b96a30b-9aff-4f60-ab3d-590832925f63.png)

# Checklist:

- [X] Changes have new/updated automated tests, if applicable
- [X] Changes have new/updated docs, if applicable
- [X] I have performed a self-review of my own code
- [X] I have added comments on any new, hard-to-understand code
- [X] Changes have been manually tested
- [X] Changes generate no new errors or warnings
