### PR TITLE
Modify  /api/users to support pagination

### DIFF
--- a/server/api/users/users.controller.ts
+++ b/server/api/users/users.controller.ts
@@ -7,6 +7,8 @@ import { UserProfile } from 'server/types/User';
 
 type ClientUser = Pick<User, 'id' | 'discord_user_id'>
 
+export const USERS_LIMIT = 20;
+
 export const getCurrentUser: RequestHandler<void, ClientUser> = (req, res) => {
   // eslint-disable-next-line  @typescript-eslint/no-non-null-assertion
   const filteredUser = _.pick(req.user!, [
@@ -30,8 +32,7 @@ export const getUserById: RequestHandler<{id: string}, UserProfile> = async (req
 
 export const getUsers: RequestHandler = async (req, res) => {
   const page = req.query.page ? parseInt(req.query.page as string, 10) : 1;
-  const limit = 20;
-  const offset = (page - 1) * limit;
+  const offset = (page - 1) * USERS_LIMIT;
 
   if (!Number.isInteger(page) || page < 1) {
     throw new BadRequestError('Invalid page number');
@@ -39,14 +40,14 @@ export const getUsers: RequestHandler = async (req, res) => {
 
   const { rows: users, count } = await User.findAndCountAll({
     attributes: User.allowedFields,
-    limit: limit,
+    limit: USERS_LIMIT,
     offset: offset,
     order: [
       ['id', 'ASC'],
     ],
   });
 
-  const totalPages = Math.ceil(count / limit) || 1;
+  const totalPages = Math.ceil(count / USERS_LIMIT) || 1;
 
   if (offset >= count && page !== 1) {
     throw new BadRequestError('Page out of range');

--- a/server/api/users/users.controller.ts
+++ b/server/api/users/users.controller.ts
@@ -41,9 +41,12 @@ export const getUsers: RequestHandler = async (req, res) => {
     attributes: User.allowedFields,
     limit: limit,
     offset: offset,
+    order: [
+      ['id', 'ASC'],
+    ],
   });
 
-  const totalPages = Math.ceil(count / limit);
+  const totalPages = Math.ceil(count / limit) || 1;
 
   if (offset >= count && page !== 1) {
     throw new BadRequestError('Page out of range');

--- a/server/api/users/users.test.ts
+++ b/server/api/users/users.test.ts
@@ -37,56 +37,54 @@ describe('auth router', () => {
   });
 
   describe('GET /', () => {
-    it('expects empty array if no users exist on the homepage', async () => {
+    it('API endpoint exists', async () => {
       const res = await server.exec.get('/api/users/');
+      expect(res.status).toBe(200);
+    });
+
+    it('expects empty array if no users exist', async () => {
+      const res = await server.exec.get('/api/users/');
+      expect(res.body.page).toEqual(1);
+      expect(res.body.totalPages).toEqual(0);
       expect(res.body.users).toStrictEqual([]);
     });
 
     it('expect invalid page request to return invalid page', async () => {
       const res = await server.exec.get('/api/users/?page=-1');
-      expect(res.status).toBe(400);
-      expect(res.body.error).toEqual('Invalid page number');
+      expect(res.body.message).toEqual('Invalid page number');
+    });
+
+    it('expect invalid page request to return invalid page', async () => {
+      const res = await server.exec.get('/api/users/?page=a');
+      expect(res.body.message).toEqual('Invalid page number');
     });
 
     it('expect page request beyond page limit to be out of range', async () => {
       const res = await server.exec.get('/api/users/?page=100');
-      expect(res.status).toBe(400);
-      expect(res.body.error).toEqual('Page out of range');
+      expect(res.body.message).toEqual('Page out of range');
     });
 
-    it('returns first 20 users when it hits the homepage', async () => {
-
-      const users: User[] = [];
-
-      for(let i = 0; i < 25; i++){
-        const user = await createUser();
-        users.push(user);
-      }
+    it('returns an array of 20 users', async () => {
+      const count = 25;
+      const users: User[] = await Promise.all(Array.from({ length: count }, createUser));
+      users.sort((a, b) => a.id - b.id);
 
       const limit = 20;
-      const count = await User.count();
       const totalPages = Math.ceil(count / limit);
 
       const res = await server.exec.get('/api/users/');
       expect(res.status).toBe(200);
       expect(res.body.users.length).toEqual(limit);
-      expect(res.body.users[0]).toEqual(getExpectedUserObject(users[0]));
-      expect(res.body.users[19]).toEqual(getExpectedUserObject(users[19]));
       expect(res.body.page).toEqual(1);
       expect(res.body.totalPages).toEqual(totalPages);
     });
 
     it('returns last 5 users when it hits the second page', async () => {
-
-      const users: User[] = [];
-
-      for(let i = 0; i < 25; i++){
-        const user = await createUser();
-        users.push(user);
-      }
+      const count = 25;
+      const users: User[] = await Promise.all(Array.from({ length: count }, createUser));
+      users.sort((a, b) => a.id - b.id);
 
       const limit = 20;
-      const count = await User.count();
       const totalPages = Math.ceil(count / limit);
 
       const res = await server.exec.get('/api/users?page=2');
@@ -94,7 +92,6 @@ describe('auth router', () => {
       expect(res.status).toBe(200);
       expect(res.body.users.length).toEqual(5);
       expect(res.body.users[0]).toEqual(getExpectedUserObject(users[20]));
-      expect(res.body.users[4]).toEqual(getExpectedUserObject(users[24]));
       expect(res.body.page).toEqual(2);
       expect(res.body.totalPages).toEqual(totalPages);
     });

--- a/server/api/users/users.test.ts
+++ b/server/api/users/users.test.ts
@@ -43,24 +43,24 @@ describe('auth router', () => {
     });
 
     it('expect invalid page request to return invalid page', async () => {
-      const res = await server.exec.get('/api/users/?page=-1')
-      expect(res.status).toBe(400)
-      expect(res.body.error).toEqual('Invalid page number')
-    })
+      const res = await server.exec.get('/api/users/?page=-1');
+      expect(res.status).toBe(400);
+      expect(res.body.error).toEqual('Invalid page number');
+    });
 
     it('expect page request beyond page limit to be out of range', async () => {
-      const res = await server.exec.get('/api/users/?page=100')
-      expect(res.status).toBe(400)
-      expect(res.body.error).toEqual('Page out of range')
-    })
+      const res = await server.exec.get('/api/users/?page=100');
+      expect(res.status).toBe(400);
+      expect(res.body.error).toEqual('Page out of range');
+    });
 
     it('returns first 20 users when it hits the homepage', async () => {
 
-      const users: User[] = []; 
+      const users: User[] = [];
 
       for(let i = 0; i < 25; i++){
         const user = await createUser();
-        users.push(user)
+        users.push(user);
       }
 
       const limit = 20;
@@ -69,20 +69,20 @@ describe('auth router', () => {
 
       const res = await server.exec.get('/api/users/');
       expect(res.status).toBe(200);
-      expect(res.body.users.length).toEqual(limit)
+      expect(res.body.users.length).toEqual(limit);
       expect(res.body.users[0]).toEqual(getExpectedUserObject(users[0]));
       expect(res.body.users[19]).toEqual(getExpectedUserObject(users[19]));
-      expect(res.body.page).toEqual(1)
-      expect(res.body.totalPages).toEqual(totalPages)
+      expect(res.body.page).toEqual(1);
+      expect(res.body.totalPages).toEqual(totalPages);
     });
 
     it('returns first 20 users when it hits the homepage', async () => {
 
-      const users: User[] = []; 
+      const users: User[] = [];
 
       for(let i = 0; i < 25; i++){
         const user = await createUser();
-        users.push(user)
+        users.push(user);
       }
 
       const limit = 20;
@@ -92,13 +92,13 @@ describe('auth router', () => {
       const res = await server.exec.get('/api/users?page=2');
 
       expect(res.status).toBe(200);
-      expect(res.body.users.length).toEqual(5)
+      expect(res.body.users.length).toEqual(5);
       expect(res.body.users[0]).toEqual(getExpectedUserObject(users[20]));
       expect(res.body.users[4]).toEqual(getExpectedUserObject(users[24]));
-      expect(res.body.page).toEqual(2)
-      expect(res.body.totalPages).toEqual(totalPages)
+      expect(res.body.page).toEqual(2);
+      expect(res.body.totalPages).toEqual(totalPages);
     });
-  })
+  });
 
   describe('PATCH /:id', () => {
     it('returns 403 if profile id is not equal to logged in user id', async () => {

--- a/server/api/users/users.test.ts
+++ b/server/api/users/users.test.ts
@@ -76,7 +76,7 @@ describe('auth router', () => {
       expect(res.body.totalPages).toEqual(totalPages);
     });
 
-    it('returns first 20 users when it hits the homepage', async () => {
+    it('returns last 5 users when it hits the second page', async () => {
 
       const users: User[] = [];
 


### PR DESCRIPTION
Closes #58 

# Description

Modifies `/api/users` to support pagination

## Testing

A bit hard to test manual in local because #39 is not yet completed.

hitting `localhost:3000/api/users` should return first 20 users in db
hitting `localhost:3000/api/users?page=-1` or `localhost:3000/api/users?page=a` should return 400 Invalid page
hitting a page beyond homepage that has no users (I.E `localhost:3000/api/users?page=9001`) should return 400 Page out of bounds

can also execute `npm run test`

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshots

No

# Checklist:

- [x] Changes have new/updated automated tests, if applicable
- [x] Changes have new/updated docs, if applicable
- [x] I have performed a self-review of my own code
- [x] I have added comments on any new, hard-to-understand code
- [x] Changes have been manually tested
- [x] Changes generate no new errors or warnings
