### PR TITLE
discord_name should never be empty since we use discord auth

### DIFF
--- a/server/test/utils.ts
+++ b/server/test/utils.ts
@@ -43,7 +43,7 @@ function makeUserObject({
   return {
     email: email ?? randEmail(),
     discord_user_id: discord_user_id ?? String(randNumber({ min: 1e16, max: 1e18 - 1 })),
-    discord_name: discord_name ?? randomEmptyChance(20, getRandomDiscordUserName()),
+    discord_name: discord_name ?? getRandomDiscordUserName(),
     bio: bio ?? randomEmptyChance(20, randQuote()),
     twitter_username: twitter_username ?? randomEmptyChance(20, randUserName()),
     linkedin_url: linkedin_url ?? randomEmptyChance(20, getRandomLinkedInURL()),
@@ -71,10 +71,4 @@ function getExpectedUserObject(user: User) {
   return pickedUser as User;
 }
 
-export {
-  randomEmptyChance,
-  createUser,
-  getExpectedUserObject,
-  makeUserObject,
-  createUsers,
-};
+export { randomEmptyChance, createUser, getExpectedUserObject, makeUserObject, createUsers };

--- a/server/test/utils.ts
+++ b/server/test/utils.ts
@@ -71,4 +71,10 @@ function getExpectedUserObject(user: User) {
   return pickedUser as User;
 }
 
-export { randomEmptyChance, createUser, getExpectedUserObject, makeUserObject, createUsers };
+export {
+  randomEmptyChance,
+  createUser,
+  getExpectedUserObject,
+  makeUserObject,
+  createUsers,
+};


### PR DESCRIPTION
# Description

Found a small bug in the implementation of `makeUserObject` which `discord_name` has a random empty chance. There should be no scenario where we don't get the `discord_name` since we are using discord auth to set up users

## Testing
not much to test, one line change

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] Changes have new/updated automated tests, if applicable
- [ ] Changes have new/updated docs, if applicable
- [x] I have performed a self-review of my own code
- [ ] I have added comments on any new, hard-to-understand code
- [x] Changes have been manually tested
- [x] Changes generate no new errors or warnings
