### PR TITLE
🧪 test(cypress): add dev-only routes & commands for testing

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,9 +37,12 @@ jobs:
 
       - name: Run linters
         run: docker exec dev-directory_app_1 npm run lint:fix
-      
+
       - name: Run Jest tests
         run: docker exec dev-directory_app_1 npm run jest -- --roots='./dist'
+
+      - name: Run migrations
+        run: docker exec dev-directory_app_1 npm run migrate
 
       - name: Run Cypress tests
         uses: cypress-io/github-action@v5.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine  
+FROM node:18-alpine
 
 WORKDIR /app
 
@@ -7,6 +7,8 @@ COPY . .
 RUN npm ci
 
 RUN npm run build
+
+RUN npm run migrate
 
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:18-alpine  
 
 WORKDIR /app
 
@@ -7,8 +7,6 @@ COPY . .
 RUN npm ci
 
 RUN npm run build
-
-RUN npm run migrate
 
 EXPOSE 3000
 

--- a/cypress/e2e/dev.spec.ts
+++ b/cypress/e2e/dev.spec.ts
@@ -2,6 +2,10 @@ import '../support/commands';
 
 // Example tests demonstrating use of the utility functions.
 describe('example login test', () => {
+  afterEach(() => {
+    cy.truncateDatabase();
+  });
+
   it('allows a user to login and logout', () => {
     cy.visit('http://localhost:3000');
     cy.contains('a', 'Log in').should('exist');

--- a/cypress/e2e/dev.spec.ts
+++ b/cypress/e2e/dev.spec.ts
@@ -1,6 +1,7 @@
 import '../support/commands';
 
-describe('example test', () => {
+// Example tests demonstrating use of the utility functions.
+describe('example login test', () => {
   it('allows a user to login and logout', () => {
     cy.visit('http://localhost:3000');
     cy.contains('a', 'Log in').should('exist');
@@ -13,5 +14,33 @@ describe('example test', () => {
     cy.contains('a', 'Log in').should('exist');
   });
 });
+
+describe('example run-util test', () => {
+  it('can call other utility functions and access the response', () => {
+    cy.runUtil('makeUserObject').then(response => {
+      const body = response.body as { discord_name: string };
+      expect(body.discord_name).to.exist;
+    });
+  });
+});
+
+// Example test would be too closely tied to the temporary UI
+// Left here for reference, but should remain commented.
+//
+// describe('example create users/truncate test', () => {
+//   it('can create users and truncate the database afterwards', () => {
+//     cy.truncateDatabase();
+//     cy.visit('http://localhost:3000/directory');
+//     cy.get('ul li').should('have.length', 0);
+//
+//     cy.createUsers(20);
+//     cy.visit('http://localhost:3000/directory');
+//     cy.get('ul li').should('have.length', 20);
+//
+//     cy.truncateDatabase();
+//     cy.visit('http://localhost:3000/directory');
+//     cy.get('ul li').should('have.length', 0);
+//   });
+// });
 
 export {};

--- a/cypress/e2e/dev.spec.ts
+++ b/cypress/e2e/dev.spec.ts
@@ -1,0 +1,13 @@
+import '../support/commands';
+
+describe('example test', () => {
+  it('allows a guest to login', () => {
+    cy.visit('http://localhost:3000');
+    cy.get('a').contains('Log in').should('have.length', 1);
+
+    cy.login().reload();
+    cy.get('button').contains('Log out').should('have.length', 1);
+  });
+});
+
+export {};

--- a/cypress/e2e/dev.spec.ts
+++ b/cypress/e2e/dev.spec.ts
@@ -1,12 +1,16 @@
 import '../support/commands';
 
 describe('example test', () => {
-  it('allows a guest to login', () => {
+  it('allows a user to login and logout', () => {
     cy.visit('http://localhost:3000');
-    cy.get('a').contains('Log in').should('have.length', 1);
+    cy.contains('a', 'Log in').should('exist');
 
     cy.login().reload();
-    cy.get('button').contains('Log out').should('have.length', 1);
+    const logoutBtn = cy.contains('button', 'Log out');
+    logoutBtn.should('exist');
+
+    logoutBtn.click();
+    cy.contains('a', 'Log in').should('exist');
   });
 });
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -18,30 +18,32 @@ declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Cypress {
     interface Chainable {
-      createUsers(count?: number): Chainable<void>;
-      login(id?: number): Chainable<void>;
-      seedDatabase(): Chainable<void>;
-      truncateDatabase(): Chainable<void>;
+      createUsers(count?: number): Chainable<Response<unknown>>;
+      login(id?: number): Chainable<Response<unknown>>;
+      truncateDatabase(): Chainable<Response<unknown>>;
+      runUtil(method: string, ...args: unknown[]): Chainable<Response<unknown>>;
     }
   }
 }
 
 Cypress.Commands.add('createUsers', (count?: number) => {
-  const countStr = count !== undefined ? `/${count}` : '';
-  cy.request('GET', `http://localhost:3000/api/dev/create-users${countStr}`);
+  return cy.runUtil('createUsers', count);
 });
 
 Cypress.Commands.add('login', (id?: number) => {
   const idStr = id !== undefined ? `/${id}` : '';
-  cy.request('GET', `http://localhost:3000/api/dev/login${idStr}`);
-});
-
-Cypress.Commands.add('seedDatabase', () => {
-  cy.request('GET', 'http://localhost:3000/api/dev/seed-database');
+  return cy.request('GET', `http://localhost:3000/api/dev/login${idStr}`);
 });
 
 Cypress.Commands.add('truncateDatabase', () => {
-  cy.request('GET', 'http://localhost:3000/api/dev/truncate-database');
+  return cy.runUtil('truncateDatabase');
+});
+
+Cypress.Commands.add('runUtil', (method, ...args) => {
+  return cy.request('POST', 'http://localhost:3000/api/dev/run-util', {
+    method,
+    args: Object.values(args),
+  });
 });
 
 export = {};

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,38 +1,47 @@
 /// <reference types="cypress" />
-// ***********************************************
-// This example commands.ts shows you how to
-// create various custom commands and overwrite
-// existing commands.
-//
-// For more comprehensive examples of custom
-// commands please read more here:
+
 // https://on.cypress.io/custom-commands
-// ***********************************************
-//
 //
 // -- This is a parent command --
 // Cypress.Commands.add('login', (email, password) => { ... })
 //
-//
 // -- This is a child command --
 // Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
-//
 //
 // -- This is a dual command --
 // Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
 //
-//
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
-//
-// declare global {
-//   namespace Cypress {
-//     interface Chainable {
-//       login(email: string, password: string): Chainable<void>
-//       drag(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
-//       dismiss(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
-//       visit(originalFn: CommandOriginalFn, url: string, options: Partial<VisitOptions>): Chainable<Element>
-//     }
-//   }
-// }
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Cypress {
+    interface Chainable {
+      createUsers(count?: number): Chainable<void>;
+      login(id?: number): Chainable<void>;
+      truncateDatabase(): Chainable<void>;
+      seedDatabase(): Chainable<void>;
+    }
+  }
+}
+
+Cypress.Commands.add('createUsers', (count?: number) => {
+  const countStr = count !== undefined ? `/${count}` : '';
+  cy.request('GET', `http://localhost:3000/api/dev/create-users${countStr}`);
+});
+
+Cypress.Commands.add('login', (id?: number) => {
+  const idStr = id !== undefined ? `/${id}` : '';
+  cy.request('GET', `http://localhost:3000/api/dev/login${idStr}`);
+});
+
+Cypress.Commands.add('truncateDatabase', () => {
+  cy.request('GET', 'http://localhost:3000/api/dev/truncate-database');
+});
+
+Cypress.Commands.add('seedDatabase', () => {
+  cy.request('GET', 'http://localhost:3000/api/dev/seed-database');
+});
+
 export = {};

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -40,10 +40,7 @@ Cypress.Commands.add('truncateDatabase', () => {
 });
 
 Cypress.Commands.add('runUtil', (method, ...args) => {
-  return cy.request('POST', 'http://localhost:3000/api/dev/run-util', {
-    method,
-    args: Object.values(args),
-  });
+  return cy.request('POST', 'http://localhost:3000/api/dev/run-util', { method, args });
 });
 
 export = {};

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -20,8 +20,8 @@ declare global {
     interface Chainable {
       createUsers(count?: number): Chainable<void>;
       login(id?: number): Chainable<void>;
-      truncateDatabase(): Chainable<void>;
       seedDatabase(): Chainable<void>;
+      truncateDatabase(): Chainable<void>;
     }
   }
 }
@@ -36,12 +36,12 @@ Cypress.Commands.add('login', (id?: number) => {
   cy.request('GET', `http://localhost:3000/api/dev/login${idStr}`);
 });
 
-Cypress.Commands.add('truncateDatabase', () => {
-  cy.request('GET', 'http://localhost:3000/api/dev/truncate-database');
-});
-
 Cypress.Commands.add('seedDatabase', () => {
   cy.request('GET', 'http://localhost:3000/api/dev/seed-database');
+});
+
+Cypress.Commands.add('truncateDatabase', () => {
+  cy.request('GET', 'http://localhost:3000/api/dev/truncate-database');
 });
 
 export = {};

--- a/server/api/dev/dev.controller.ts
+++ b/server/api/dev/dev.controller.ts
@@ -1,0 +1,75 @@
+import { cleanEnv } from 'envalid';
+import { RequestHandler } from 'express';
+import { InternalServerError, NotFoundError } from 'express-response-errors';
+
+import { createAuthToken } from 'server/lib/auth';
+import log from 'server/lib/log';
+import { User } from 'server/models';
+import { createUser, createUsers, truncateDatabase } from 'server/test/utils';
+import { AUTH_COOKIE_NAME } from 'shared/constants';
+
+const env = cleanEnv(process.env, {});
+
+const getCreateUsers: RequestHandler<{ count?: string }, { status: string; data: User[] }> = async (req, res) => {
+  const count = req.params?.count ? parseInt(req.params?.count as string, 10) : 1;
+  let users: User[];
+
+  try {
+    users = await createUsers(count);
+
+    res.json({ status: 'Success', data: users });
+    res.status(200);
+  } catch (error) {
+    throw new InternalServerError('Unable to create user');
+  }
+};
+
+const getLogin: RequestHandler<{ id?: string }> = async (req, res) => {
+  const userId = req.params.id ? parseInt(req.params.id as string, 10) : null;
+
+  let user: User;
+  if (userId != null) {
+    user = await User.findByPk(userId, { attributes: User.allowedFields });
+    if (!user) throw new NotFoundError('User not found');
+  } else {
+    user = await createUser();
+    if (!user) throw new InternalServerError('Unable to create user');
+  }
+
+  const token = createAuthToken(user);
+
+  res.cookie(AUTH_COOKIE_NAME, token, { secure: env.isProd });
+  res.sendStatus(200);
+};
+
+const getTruncateDatabase: RequestHandler = async (req, res) => {
+  try {
+    await truncateDatabase();
+
+    res.json({ status: 'Success', message: 'Database truncated' });
+    res.status(200);
+  } catch (error) {
+    log(`Unable to truncate database: ${error.message}`);
+    throw new InternalServerError('Unable to truncate database');
+  }
+};
+
+const getSeedDatabase: RequestHandler = async (req, res) => {
+  try {
+    // Doesn't populate future tables
+    await createUsers(100);
+
+    res.json({ status: 'Success', message: 'Database seeded' });
+    res.status(200);
+  } catch (error) {
+    log(`Unable to seed database: ${error.message}`);
+    throw new InternalServerError('Unable to seed database');
+  }
+};
+
+export {
+  getCreateUsers,
+  getLogin,
+  getTruncateDatabase,
+  getSeedDatabase,
+};

--- a/server/api/dev/dev.controller.ts
+++ b/server/api/dev/dev.controller.ts
@@ -28,7 +28,7 @@ const getLogin: RequestHandler<{ id?: string }> = async (req, res) => {
   res.sendStatus(200);
 };
 
-const postRunUtil: RequestHandler<{ method: string; args: string[] }> = async (req, res) => {
+const postRunUtil: RequestHandler<{ method: string; args: unknown[] }> = async (req, res) => {
   const { method, args } = req.body;
 
   try {

--- a/server/api/dev/dev.controller.ts
+++ b/server/api/dev/dev.controller.ts
@@ -42,18 +42,6 @@ const getLogin: RequestHandler<{ id?: string }> = async (req, res) => {
   res.sendStatus(200);
 };
 
-const getTruncateDatabase: RequestHandler = async (req, res) => {
-  try {
-    await truncateDatabase();
-
-    res.json({ status: 'Success', message: 'Database truncated' });
-    res.status(200);
-  } catch (error) {
-    log(`Unable to truncate database: ${error.message}`);
-    throw new InternalServerError('Unable to truncate database');
-  }
-};
-
 const getSeedDatabase: RequestHandler = async (req, res) => {
   try {
     // Doesn't populate future tables
@@ -67,9 +55,21 @@ const getSeedDatabase: RequestHandler = async (req, res) => {
   }
 };
 
+const getTruncateDatabase: RequestHandler = async (req, res) => {
+  try {
+    await truncateDatabase();
+
+    res.json({ status: 'Success', message: 'Database truncated' });
+    res.status(200);
+  } catch (error) {
+    log(`Unable to truncate database: ${error.message}`);
+    throw new InternalServerError('Unable to truncate database');
+  }
+};
+
 export {
   getCreateUsers,
   getLogin,
-  getTruncateDatabase,
   getSeedDatabase,
+  getTruncateDatabase,
 };

--- a/server/api/dev/dev.test.ts
+++ b/server/api/dev/dev.test.ts
@@ -1,0 +1,122 @@
+import jwt from 'jsonwebtoken';
+import setCookie, { Cookie } from 'set-cookie-parser';
+import { Response } from 'superagent';
+
+import Db from 'server/lib/db';
+import { User } from 'server/models';
+import TestServer from 'server/test/server';
+import { createUser, createUsers, truncateDatabase } from 'server/test/utils';
+import { AUTH_COOKIE_NAME } from 'shared/constants';
+
+describe('developer/testing routes', () => {
+  let server: TestServer;
+
+  const excludedModels = ['SequelizeMeta'];
+  const models = Object.keys(Db.sequelize.models)
+    .filter(key => excludedModels.includes(key));
+
+  beforeAll(async () => {
+    server = new TestServer();
+    await server.init();
+  });
+
+  afterAll(async () => {
+    await server.destroy();
+  });
+
+  afterEach(async () => {
+    await truncateDatabase();
+  });
+
+  describe('GET /api/dev/create-users', () => {
+    it('creates a single user if no count is specified', async () => {
+      const res = await server.exec.get('/api/dev/create-users');
+      const userCount = await User.count();
+
+      expect(res.status).toBe(200);
+      expect(userCount).toBe(1);
+    });
+
+    it('creates a specified number of users', async () => {
+      const res = await server.exec.get('/api/dev/create-users/19');
+      const userCount = await User.count();
+
+      expect(res.status).toBe(200);
+      expect(userCount).toBe(19);
+    });
+  });
+
+  describe('GET /api/dev/login', () => {
+    it('will return NotFoundError if specified user doesn\'t exist', async () => {
+      const res = await server.exec.get('/api/dev/login/9999');
+
+      expect(res.status).toBe(404);
+      expect(res.body.message).toBe('User not found');
+    });
+
+    it('can login as the specified user', async () => {
+      const user = await createUser();
+      const res = await server.exec.get(`/api/dev/login/${user.id}`);
+
+      const cookie = getCookie(res, AUTH_COOKIE_NAME);
+      const cookiePayload = jwt.decode(cookie.value) as { user_id: number };
+      const createdUser = await User.findOne({ where: { id: cookiePayload.user_id }});
+
+      expect(res.status).toBe(200);
+      expect(createdUser.id).toEqual(cookiePayload.user_id);
+    });
+
+    it('will create and login as the new user if no id is specified', async () => {
+      const res = await server.exec.get('/api/dev/login');
+
+      const cookie = getCookie(res, AUTH_COOKIE_NAME);
+      const cookiePayload = jwt.decode(cookie.value) as { user_id: number };
+      const createdUser = await User.findOne({ where: { id: cookiePayload.user_id }});
+
+      expect(res.status).toBe(200);
+      expect(createdUser.id).toEqual(cookiePayload.user_id);
+    });
+  });
+
+  describe('GET /api/dev/truncate-database', () => {
+    it('can truncate the database', async () => {
+      // Doesn't populate future tables
+      await createUsers(20);
+
+      for (const model of models) {
+        const count = await Db.sequelize.models[model].count();
+        expect(count).toBeGreaterThan(0);
+      }
+
+      const res = await server.exec.get('/api/dev/truncate-database');
+      for (const model of models) {
+        const count = await Db.sequelize.models[model].count();
+        expect(count).toBe(0);
+      }
+
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Database truncated');
+    });
+  });
+
+  describe('GET /api/dev/seed-database', () => {
+    it('can seed the database', async () => {
+      // Doesn't populate future tables
+      const res = await server.exec.get('/api/dev/seed-database');
+
+      for (const model of models) {
+        const count = await Db.sequelize.models[model].count();
+        expect(count).toBeGreaterThan(0);
+      }
+
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Database seeded');
+    });
+  });
+});
+
+function getCookie(res: Response, name: string): Cookie {
+  return res.headers['set-cookie']
+    .map((cookieString: string) => setCookie.parse(cookieString)[0])
+    .find((cookie: Cookie) => cookie.name === name);
+}

--- a/server/api/dev/index.ts
+++ b/server/api/dev/index.ts
@@ -1,0 +1,12 @@
+import { AsyncRouter } from 'express-async-router';
+
+import { getCreateUsers, getLogin, getTruncateDatabase, getSeedDatabase } from 'server/api/dev/dev.controller';
+
+const devRouter = AsyncRouter();
+
+devRouter.get('/create-users/:count?', getCreateUsers);
+devRouter.get('/login/:id?', getLogin);
+devRouter.get('/truncate-database', getTruncateDatabase);
+devRouter.get('/seed-database', getSeedDatabase);
+
+export default devRouter;

--- a/server/api/dev/index.ts
+++ b/server/api/dev/index.ts
@@ -1,12 +1,10 @@
 import { AsyncRouter } from 'express-async-router';
 
-import { getCreateUsers, getLogin, getTruncateDatabase, getSeedDatabase } from 'server/api/dev/dev.controller';
+import { getLogin, postRunUtil } from 'server/api/dev/dev.controller';
 
 const devRouter = AsyncRouter();
 
-devRouter.get('/create-users/:count?', getCreateUsers);
 devRouter.get('/login/:id?', getLogin);
-devRouter.get('/truncate-database', getTruncateDatabase);
-devRouter.get('/seed-database', getSeedDatabase);
+devRouter.post('/run-util', postRunUtil);
 
 export default devRouter;

--- a/server/api/index.ts
+++ b/server/api/index.ts
@@ -13,7 +13,7 @@ const env = cleanEnv(process.env, {});
 apiRouter.use('/users', userRouter);
 apiRouter.use('/auth', authRouter);
 
-if (!env.isProd) {
+if (env.isDev || env.isTest) {
   // These should NEVER be loaded in production.
   apiRouter.use('/dev', devRouter);
 }

--- a/server/api/index.ts
+++ b/server/api/index.ts
@@ -1,11 +1,21 @@
+import { cleanEnv } from 'envalid';
 import { AsyncRouter } from 'express-async-router';
+
+import devRouter from 'server/api/dev';
 
 import authRouter from './auth';
 import userRouter from './users';
 
 const apiRouter = AsyncRouter();
 
+const env = cleanEnv(process.env, {});
+
 apiRouter.use('/users', userRouter);
 apiRouter.use('/auth', authRouter);
+
+if (!env.isProd) {
+  // These should NEVER be loaded in production.
+  apiRouter.use('/dev', devRouter);
+}
 
 export default apiRouter;

--- a/server/test/utils.ts
+++ b/server/test/utils.ts
@@ -71,10 +71,18 @@ function getExpectedUserObject(user: User) {
   return pickedUser as User;
 }
 
+async function truncateDatabase() {
+  for (const model in Db.sequelize.models) {
+    if (model === 'SequelizeMeta') continue;
+    await Db.sequelize.models[model].destroy({ truncate: true, restartIdentity: true });
+  }
+}
+
 export {
-  randomEmptyChance,
   createUser,
+  createUsers,
   getExpectedUserObject,
   makeUserObject,
-  createUsers,
+  randomEmptyChance,
+  truncateDatabase,
 };


### PR DESCRIPTION
Closes N/A

# Description

This PR adds some developer-only routes and utilities to aid with writing Cypress tests.

Routes Added:
- `GET /api/dev/login/:id?`
  If no `id` is provided, a **new** user is created and logged in.
- `POST /api/dev/run-util`
  Expects a body of `{ method: string; args: unknown[] }`.

Cypres Commands Added (aliases for the routes above):
- `createUsers(count?: number)`
- `login(id?: number)`
- `truncateDatabase()`
- `runUtil(method: string, ...args: unknown[])`
  This method can run any of the exported `/server/test/utils` functions. It accepts the method's name as the first parameter and the arguments to pass into the function as subsequent parameters.

Extras:
- `/cypress/e2e/dev.spec.ts` was added to demonstrate the use of the newly added commands & endpoint.

## Testing

Run automated tests, both Jest and Cypress.

## Type of change

Please remove all except for everything applicable, and then remove this line.

- Other (test utilities)

## Screenshots

N/A

# Checklist:

- [X] Changes have new/updated automated tests, if applicable
- [X] Changes have new/updated docs, if applicable
- [X] I have performed a self-review of my own code
- [X] I have added comments on any new, hard-to-understand code
- [X] Changes have been manually tested
- [X] Changes generate no new errors or warnings
