### PR TITLE
conditionally import dev router

### DIFF
--- a/server/api/index.ts
+++ b/server/api/index.ts
@@ -1,8 +1,6 @@
 import { cleanEnv } from 'envalid';
 import { AsyncRouter } from 'express-async-router';
 
-import devRouter from 'server/api/dev';
-
 import authRouter from './auth';
 import userRouter from './users';
 
@@ -14,6 +12,7 @@ apiRouter.use('/users', userRouter);
 apiRouter.use('/auth', authRouter);
 
 if (env.isDev || env.isTest) {
+  const devRouter = require('./dev').default; // eslint-disable-line @typescript-eslint/no-var-requires
   // These should NEVER be loaded in production.
   apiRouter.use('/dev', devRouter);
 }

--- a/server/api/index.ts
+++ b/server/api/index.ts
@@ -12,6 +12,7 @@ apiRouter.use('/users', userRouter);
 apiRouter.use('/auth', authRouter);
 
 if (env.isDev || env.isTest) {
+  // we can't import this router because it requires dev dependencies
   const devRouter = require('./dev').default; // eslint-disable-line @typescript-eslint/no-var-requires
   // These should NEVER be loaded in production.
   apiRouter.use('/dev', devRouter);


### PR DESCRIPTION
# Description

The dev router was importing some dev-only dependencies that were used in the test utils. This was the error in the heroku logs for staging:

```
2023-04-30T23:15:59.930969+00:00 heroku[web.1]: Starting process with command `node dist/server/index`
2023-04-30T23:16:01.396176+00:00 app[web.1]: node:internal/modules/cjs/loader:1078
2023-04-30T23:16:01.396200+00:00 app[web.1]:   throw err;
2023-04-30T23:16:01.396201+00:00 app[web.1]:   ^
2023-04-30T23:16:01.396201+00:00 app[web.1]: 
2023-04-30T23:16:01.396201+00:00 app[web.1]: Error: Cannot find module '@ngneat/falso'
2023-04-30T23:16:01.396201+00:00 app[web.1]: Require stack:
2023-04-30T23:16:01.396201+00:00 app[web.1]: - /app/dist/server/test/utils.js
2023-04-30T23:16:01.396202+00:00 app[web.1]: - /app/dist/server/api/dev/dev.controller.js
2023-04-30T23:16:01.396202+00:00 app[web.1]: - /app/dist/server/api/dev/index.js
2023-04-30T23:16:01.396202+00:00 app[web.1]: - /app/dist/server/api/index.js
2023-04-30T23:16:01.396202+00:00 app[web.1]: - /app/dist/server/server.js
2023-04-30T23:16:01.396203+00:00 app[web.1]: - /app/dist/server/index.js
```

This change makes the dev router dynamically imported _only_ if it's going to be used.

## Testing

N/A

## Type of change

Please remove all except for everything applicable, and then remove this line.

- Bug fix (non-breaking change which fixes an issue)
- Change to documentation/GitHub flows/CICD

# Checklist:

- [x] Changes have new/updated automated tests, if applicable
- [x] Changes have new/updated docs, if applicable
- [x] I have performed a self-review of my own code
- [x] I have added comments on any new, hard-to-understand code
- [ ] Changes have been manually tested
- [x] Changes generate no new errors or warnings
