### PR TITLE
build layout components, auth contexts, perma dark mode

### DIFF
--- a/client/components/layout/Header.tsx
+++ b/client/components/layout/Header.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
 import { Box } from '@mui/material';
 import Link from 'next/link';
+import React from 'react';
+
 import Navigation from './Navigation';
 
 const Header: React.FC = () => {

--- a/client/components/layout/Header.tsx
+++ b/client/components/layout/Header.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Box } from '@mui/material';
+import Link from 'next/link';
+import Navigation from './Navigation';
+
+const Header: React.FC = () => {
+  return (
+    <Box
+      component="header"
+      className="flex align-baseline justify-between p-3"
+    >
+      <Link href="/">
+        <button className="text-lg bg-transparent border-none cursor-pointer">
+          PairUp
+        </button>
+      </Link>
+      <Navigation />
+    </Box>
+  );
+};
+
+export default Header;

--- a/client/components/layout/Header.tsx
+++ b/client/components/layout/Header.tsx
@@ -10,7 +10,7 @@ const Header: React.FC = () => {
       component="header"
       className="flex align-baseline justify-between p-3"
     >
-      <Link href="/">
+      <Link href="/" passHref>
         <button className="text-lg bg-transparent border-none cursor-pointer">
           PairUp
         </button>

--- a/client/components/layout/Layout.tsx
+++ b/client/components/layout/Layout.tsx
@@ -1,14 +1,20 @@
-import { CssBaseline } from '@mui/material';
+import { CssBaseline, ThemeProvider, createTheme } from '@mui/material';
 import React from 'react';
 import Header from './Header';
 
+const darkTheme = createTheme({
+  palette: {
+    mode: 'dark',
+  },
+});
+
 const Layout: React.FC = ({ children }) => {
   return (
-    <>
+    <ThemeProvider theme={darkTheme}>
       <CssBaseline enableColorScheme />
       <Header />
       <main>{children}</main>
-    </>
+    </ThemeProvider>
   );
 };
 

--- a/client/components/layout/Layout.tsx
+++ b/client/components/layout/Layout.tsx
@@ -1,10 +1,12 @@
 import { CssBaseline } from '@mui/material';
 import React from 'react';
+import Header from './Header';
 
 const Layout: React.FC = ({ children }) => {
   return (
     <>
       <CssBaseline enableColorScheme />
+      <Header />
       <main>{children}</main>
     </>
   );

--- a/client/components/layout/Layout.tsx
+++ b/client/components/layout/Layout.tsx
@@ -1,5 +1,6 @@
 import { CssBaseline, ThemeProvider, createTheme } from '@mui/material';
 import React from 'react';
+
 import Header from './Header';
 
 const darkTheme = createTheme({

--- a/client/components/layout/Navigation.tsx
+++ b/client/components/layout/Navigation.tsx
@@ -14,7 +14,7 @@ interface NavLink {
 }
 
 const Navigation: React.FC = () => {
-  const { authed } = useAuthState();
+  const { authedUser } = useAuthState();
   const authDispatch = useAuthDispatch();
   const router = useRouter();
 
@@ -25,7 +25,7 @@ const Navigation: React.FC = () => {
 
   const PROFILE_LINK: NavLink = {
     label: 'Profile',
-    href: '/profile',
+    href: `/profile/${authedUser?.id}`,
   };
 
   const LOGIN_LINK: NavLink = {
@@ -38,7 +38,7 @@ const Navigation: React.FC = () => {
     onClick: async () => {
       const axios = createAxiosInstance();
       await axios.post('/api/auth/logout');
-      authDispatch({ type: 'SET_AUTHED', authed: false });
+      authDispatch({ type: 'SET_AUTHED_USER', user: null });
       router.push('/');
     },
   };
@@ -54,7 +54,7 @@ const Navigation: React.FC = () => {
     LOGIN_LINK,
   ];
 
-  const links = authed ? authedNav : anonNav;
+  const links = authedUser ? authedNav : anonNav;
 
   return (
     <Box component="nav">

--- a/client/components/layout/Navigation.tsx
+++ b/client/components/layout/Navigation.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { Box, Button } from '@mui/material';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
 import createAxiosInstance from 'client/lib/axios';
 import { getDiscordOauthUrl } from 'client/lib/oauth';
-import Link from 'next/link';
+import { useAuthDispatch, useAuthState } from 'client/contexts/auth';
 
 interface NavLink {
   label: string;
@@ -10,43 +12,48 @@ interface NavLink {
   onClick?: () => void;
 }
 
-const DIRECTORY_LINK: NavLink = {
-  label: 'Discover',
-  href: '/directory',
-}
-
-const PROFILE_LINK: NavLink = {
-  label: 'Profile',
-  href: '/profile',
-}
-
-const LOGIN_LINK: NavLink = {
-  label: 'Login',
-  href: getDiscordOauthUrl(),
-}
-
-const LOGOUT_LINK: NavLink = {
-  label: 'Logout',
-  onClick: async () => {
-    const axios = createAxiosInstance();
-    await axios.post('/api/auth/logout');
-  }
-}
-
-const authedNav = [
-  DIRECTORY_LINK,
-  PROFILE_LINK,
-  LOGOUT_LINK,
-]
-
-const anonNav = [
-  DIRECTORY_LINK,
-  LOGIN_LINK,
-]
-
 const Navigation: React.FC = () => {
-  const isAuthed = true;
-  const links = isAuthed ? authedNav : anonNav;
+  const { authed } = useAuthState();
+  const authDispatch = useAuthDispatch();
+  const router = useRouter();
+
+  const DIRECTORY_LINK: NavLink = {
+    label: 'Discover',
+    href: '/directory',
+  }
+
+  const PROFILE_LINK: NavLink = {
+    label: 'Profile',
+    href: '/profile',
+  }
+
+  const LOGIN_LINK: NavLink = {
+    label: 'Login',
+    href: getDiscordOauthUrl(),
+  }
+
+  const LOGOUT_LINK: NavLink = {
+    label: 'Logout',
+    onClick: async () => {
+      const axios = createAxiosInstance();
+      await axios.post('/api/auth/logout');
+      authDispatch({ type: "SET_AUTHED", authed: false })
+      router.push("/")
+    }
+  }
+
+  const authedNav = [
+    DIRECTORY_LINK,
+    PROFILE_LINK,
+    LOGOUT_LINK,
+  ]
+
+  const anonNav = [
+    DIRECTORY_LINK,
+    LOGIN_LINK,
+  ]
+
+  const links = authed ? authedNav : anonNav;
 
   return (
     <Box component="nav">

--- a/client/components/layout/Navigation.tsx
+++ b/client/components/layout/Navigation.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Box, Button } from '@mui/material';
+import createAxiosInstance from 'client/lib/axios';
+import { getDiscordOauthUrl } from 'client/lib/oauth';
+import Link from 'next/link';
+
+interface NavLink {
+  label: string;
+  href?: string;
+  onClick?: () => void;
+}
+
+const DIRECTORY_LINK: NavLink = {
+  label: 'Discover',
+  href: '/directory',
+}
+
+const PROFILE_LINK: NavLink = {
+  label: 'Profile',
+  href: '/profile',
+}
+
+const LOGIN_LINK: NavLink = {
+  label: 'Login',
+  href: getDiscordOauthUrl(),
+}
+
+const LOGOUT_LINK: NavLink = {
+  label: 'Logout',
+  onClick: async () => {
+    const axios = createAxiosInstance();
+    await axios.post('/api/auth/logout');
+  }
+}
+
+const authedNav = [
+  DIRECTORY_LINK,
+  PROFILE_LINK,
+  LOGOUT_LINK,
+]
+
+const anonNav = [
+  DIRECTORY_LINK,
+  LOGIN_LINK,
+]
+
+const Navigation: React.FC = () => {
+  const isAuthed = true;
+  const links = isAuthed ? authedNav : anonNav;
+
+  return (
+    <Box component="nav">
+      {links.map(link => (
+        link.href ? (
+          <Link href={link.href} key={link.href}>
+            <Button onClick={link.onClick}>
+              {link.label}
+            </Button>
+          </Link>
+        ) : (
+          <Button onClick={link.onClick} key={link.label}>
+            {link.label}
+          </Button>
+        )
+      ))}
+    </Box>
+  );
+};
+
+export default Navigation;

--- a/client/components/layout/Navigation.tsx
+++ b/client/components/layout/Navigation.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
 import { Box, Button } from '@mui/material';
-import { useRouter } from 'next/router';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
+import React from 'react';
+
+import { useAuthDispatch, useAuthState } from 'client/contexts/auth';
 import createAxiosInstance from 'client/lib/axios';
 import { getDiscordOauthUrl } from 'client/lib/oauth';
-import { useAuthDispatch, useAuthState } from 'client/contexts/auth';
 
 interface NavLink {
   label: string;
@@ -20,38 +21,38 @@ const Navigation: React.FC = () => {
   const DIRECTORY_LINK: NavLink = {
     label: 'Discover',
     href: '/directory',
-  }
+  };
 
   const PROFILE_LINK: NavLink = {
     label: 'Profile',
     href: '/profile',
-  }
+  };
 
   const LOGIN_LINK: NavLink = {
     label: 'Login',
     href: getDiscordOauthUrl(),
-  }
+  };
 
   const LOGOUT_LINK: NavLink = {
     label: 'Logout',
     onClick: async () => {
       const axios = createAxiosInstance();
       await axios.post('/api/auth/logout');
-      authDispatch({ type: "SET_AUTHED", authed: false })
-      router.push("/")
-    }
-  }
+      authDispatch({ type: 'SET_AUTHED', authed: false });
+      router.push('/');
+    },
+  };
 
   const authedNav = [
     DIRECTORY_LINK,
     PROFILE_LINK,
     LOGOUT_LINK,
-  ]
+  ];
 
   const anonNav = [
     DIRECTORY_LINK,
     LOGIN_LINK,
-  ]
+  ];
 
   const links = authed ? authedNav : anonNav;
 

--- a/client/components/layout/Navigation.tsx
+++ b/client/components/layout/Navigation.tsx
@@ -60,7 +60,7 @@ const Navigation: React.FC = () => {
     <Box component="nav">
       {links.map(link => (
         link.href ? (
-          <Link href={link.href} key={link.href}>
+          <Link href={link.href} key={link.href} passHref>
             <Button onClick={link.onClick}>
               {link.label}
             </Button>

--- a/client/contexts/auth/index.tsx
+++ b/client/contexts/auth/index.tsx
@@ -1,6 +1,7 @@
-import React from 'react'
-import { AuthDispatch, AuthReducer, AuthState } from "./types";
+import React from 'react';
+
 import { reducer } from './reducer';
+import { AuthDispatch, AuthReducer, AuthState } from './types';
 
 const defaultState: AuthState = {
   authed: false,

--- a/client/contexts/auth/index.tsx
+++ b/client/contexts/auth/index.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { AuthDispatch, AuthReducer, AuthState } from "./types";
+import { reducer } from './reducer';
+
+const defaultState: AuthState = {
+  authed: false,
+};
+
+const AuthStateContext = React.createContext<AuthState>(defaultState);
+const AuthDispatchContext = React.createContext<AuthDispatch>({} as AuthDispatch);
+
+interface Props {
+  children: React.ReactNode;
+  initialState: Partial<AuthState>;
+}
+
+export const AuthContextProvider: React.FC<Props> = ({ children, initialState }) => {
+  const combinedState: AuthState = {
+    ...defaultState,
+    ...initialState,
+  };
+  const [state, dispatch] = React.useReducer<AuthReducer>(reducer, combinedState);
+
+  return (
+    <AuthDispatchContext.Provider value={dispatch}>
+      <AuthStateContext.Provider value={state}>
+        {children}
+      </AuthStateContext.Provider>
+    </AuthDispatchContext.Provider>
+  );
+};
+
+export const useAuthState = () => React.useContext(AuthStateContext);
+export const useAuthDispatch = () => React.useContext(AuthDispatchContext);

--- a/client/contexts/auth/index.tsx
+++ b/client/contexts/auth/index.tsx
@@ -4,7 +4,7 @@ import { reducer } from './reducer';
 import { AuthDispatch, AuthReducer, AuthState } from './types';
 
 const defaultState: AuthState = {
-  authed: false,
+  authedUser: null,
 };
 
 const AuthStateContext = React.createContext<AuthState>(defaultState);

--- a/client/contexts/auth/reducer.ts
+++ b/client/contexts/auth/reducer.ts
@@ -1,13 +1,13 @@
-import { produce } from "immer";
-import { AuthReducer } from "./types";
+import { produce } from 'immer';
+
+import { AuthReducer } from './types';
 
 export const reducer: AuthReducer = (state, action) => {
   switch (action.type) {
     case 'SET_AUTHED':
-      const nextState = produce(state, (draftState) => {
+      return produce(state, draftState => {
         draftState.authed = action.authed;
       });
-      return nextState;
     default:
       return state;
   }

--- a/client/contexts/auth/reducer.ts
+++ b/client/contexts/auth/reducer.ts
@@ -1,0 +1,14 @@
+import { produce } from "immer";
+import { AuthReducer } from "./types";
+
+export const reducer: AuthReducer = (state, action) => {
+  switch (action.type) {
+    case 'SET_AUTHED':
+      const nextState = produce(state, (draftState) => {
+        draftState.authed = action.authed;
+      });
+      return nextState;
+    default:
+      return state;
+  }
+};

--- a/client/contexts/auth/reducer.ts
+++ b/client/contexts/auth/reducer.ts
@@ -8,6 +8,7 @@ export const reducer: AuthReducer = (state, action) => {
       return produce(state, draftState => {
         draftState.authedUser = action.user;
       });
+
     default:
       return state;
   }

--- a/client/contexts/auth/reducer.ts
+++ b/client/contexts/auth/reducer.ts
@@ -4,9 +4,9 @@ import { AuthReducer } from './types';
 
 export const reducer: AuthReducer = (state, action) => {
   switch (action.type) {
-    case 'SET_AUTHED':
+    case 'SET_AUTHED_USER':
       return produce(state, draftState => {
-        draftState.authed = action.authed;
+        draftState.authedUser = action.user;
       });
     default:
       return state;

--- a/client/contexts/auth/types.ts
+++ b/client/contexts/auth/types.ts
@@ -1,0 +1,19 @@
+
+
+export interface AuthState {
+  authed: boolean;
+}
+
+export type AuthAction = {
+  type: 'SET_AUTHED';
+  authed: boolean;
+}
+
+// A reducer takes old state, some action, and returns the new state
+// based on that action
+export type AuthReducer = React.Reducer<AuthState, AuthAction>
+
+// A dispatch is an action that's called to update a state
+// in this case, this context
+export type AuthDispatch = React.Dispatch<AuthAction>
+

--- a/client/contexts/auth/types.ts
+++ b/client/contexts/auth/types.ts
@@ -1,11 +1,14 @@
+// todo: replace this with the shared user type once merged
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type User = Record<string, any>;
 
 export interface AuthState {
-  authed: boolean;
+  authedUser: User | null;
 }
 
 export type AuthAction = {
-  type: 'SET_AUTHED';
-  authed: boolean;
+  type: 'SET_AUTHED_USER';
+  user: AuthState['authedUser'];
 };
 
 // A reducer takes old state, some action, and returns the new state

--- a/client/contexts/auth/types.ts
+++ b/client/contexts/auth/types.ts
@@ -1,5 +1,4 @@
 
-
 export interface AuthState {
   authed: boolean;
 }
@@ -7,13 +6,13 @@ export interface AuthState {
 export type AuthAction = {
   type: 'SET_AUTHED';
   authed: boolean;
-}
+};
 
 // A reducer takes old state, some action, and returns the new state
 // based on that action
-export type AuthReducer = React.Reducer<AuthState, AuthAction>
+export type AuthReducer = React.Reducer<AuthState, AuthAction>;
 
 // A dispatch is an action that's called to update a state
 // in this case, this context
-export type AuthDispatch = React.Dispatch<AuthAction>
+export type AuthDispatch = React.Dispatch<AuthAction>;
 

--- a/cypress/e2e/base.spec.ts
+++ b/cypress/e2e/base.spec.ts
@@ -6,7 +6,7 @@ describe('Open browser and check if login button exists.', () => {
   });
 
   it('Checks if there is an anchor with the text login', () => {
-    cy.get('a').contains('Log in').should('have.length', 1);
+    cy.get('a').contains('Login').should('have.length', 1);
   });
 });
 

--- a/cypress/e2e/dev.spec.ts
+++ b/cypress/e2e/dev.spec.ts
@@ -8,14 +8,14 @@ describe('example login test', () => {
 
   it('allows a user to login and logout', () => {
     cy.visit('http://localhost:3000');
-    cy.contains('a', 'Log in').should('exist');
+    cy.contains('a', 'Login').should('exist');
 
     cy.login().reload();
-    const logoutBtn = cy.contains('button', 'Log out');
+    const logoutBtn = cy.contains('button', 'Logout');
     logoutBtn.should('exist');
 
     logoutBtn.click();
-    cy.contains('a', 'Log in').should('exist');
+    cy.contains('a', 'Login').should('exist');
   });
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "express-async-router": "^0.1.15",
         "express-response-errors": "^1.0.5",
         "he": "^1.2.0",
+        "immer": "^10.0.1",
         "jsonwebtoken": "^9.0.0",
         "lodash": "^4.17.21",
         "next": "^12.1.2",
@@ -6894,6 +6895,15 @@
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
+    },
+    "node_modules/immer": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.1.tgz",
+      "integrity": "sha512-zg++jJLsKKTwXGeSYIw0HgChSYQGtu0UDTnbKx5aGLYgte4CwTmH9eJDYyQ6FheyUtBe+lQW9FrGxya1G+Dtmg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -17196,6 +17206,11 @@
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
+    },
+    "immer": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.1.tgz",
+      "integrity": "sha512-zg++jJLsKKTwXGeSYIw0HgChSYQGtu0UDTnbKx5aGLYgte4CwTmH9eJDYyQ6FheyUtBe+lQW9FrGxya1G+Dtmg=="
     },
     "import-fresh": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "express-async-router": "^0.1.15",
     "express-response-errors": "^1.0.5",
     "he": "^1.2.0",
+    "immer": "^10.0.1",
     "jsonwebtoken": "^9.0.0",
     "lodash": "^4.17.21",
     "next": "^12.1.2",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,12 +1,12 @@
+import jwt from 'jsonwebtoken';
 import NextApp, { AppContext, AppProps } from 'next/app';
 import React from 'react';
 import Cookies from 'universal-cookie';
-import jwt from 'jsonwebtoken'
 import 'client/styles/globals.css';
 
 import Layout from 'client/components/layout/Layout';
-import { AUTH_COOKIE_NAME } from 'shared/constants';
 import { AuthContextProvider } from 'client/contexts/auth';
+import { AUTH_COOKIE_NAME } from 'shared/constants';
 
 interface Props extends AppProps {
   isAuthed: boolean;
@@ -25,20 +25,20 @@ const App = ({ Component, pageProps, isAuthed }: Props) => {
 App.getInitialProps = async (context: AppContext) => {
   const ctx = await NextApp.getInitialProps(context);
 
-  const cookies = new Cookies(context.ctx.req?.headers.cookie)
+  const cookies = new Cookies(context.ctx.req?.headers.cookie);
 
-  let isAuthed = false
+  let isAuthed = false;
 
   // Check if the user has a valid, non-expired auth token
   if (cookies.get(AUTH_COOKIE_NAME)) {
-    const authToken = cookies.get(AUTH_COOKIE_NAME)
-    const payload = jwt.decode(authToken) as jwt.JwtPayload
+    const authToken = cookies.get(AUTH_COOKIE_NAME);
+    const payload = jwt.decode(authToken) as jwt.JwtPayload;
     if (Date.now() < payload.exp * 1000) {
-      isAuthed = true
+      isAuthed = true;
     }
   }
 
-  return { ...ctx, isAuthed }
-}
+  return { ...ctx, isAuthed };
+};
 
 export default App;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,15 +1,44 @@
-import { AppProps } from 'next/app';
+import NextApp, { AppContext, AppProps } from 'next/app';
 import React from 'react';
+import Cookies from 'universal-cookie';
+import jwt from 'jsonwebtoken'
 import 'client/styles/globals.css';
 
 import Layout from 'client/components/layout/Layout';
+import { AUTH_COOKIE_NAME } from 'shared/constants';
+import { AuthContextProvider } from 'client/contexts/auth';
 
-const App = ({ Component, pageProps }: AppProps) => {
+interface Props extends AppProps {
+  isAuthed: boolean;
+}
+
+const App = ({ Component, pageProps, isAuthed }: Props) => {
   return (
-    <Layout>
-      <Component {...pageProps} />
-    </Layout>
+    <AuthContextProvider initialState={{ authed: isAuthed }}>
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
+    </AuthContextProvider>
   );
 };
+
+App.getInitialProps = async (context: AppContext) => {
+  const ctx = await NextApp.getInitialProps(context);
+
+  const cookies = new Cookies(context.ctx.req?.headers.cookie)
+
+  let isAuthed = false
+
+  // Check if the user has a valid, non-expired auth token
+  if (cookies.get(AUTH_COOKIE_NAME)) {
+    const authToken = cookies.get(AUTH_COOKIE_NAME)
+    const payload = jwt.decode(authToken) as jwt.JwtPayload
+    if (Date.now() < payload.exp * 1000) {
+      isAuthed = true
+    }
+  }
+
+  return { ...ctx, isAuthed }
+}
 
 export default App;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -11,7 +11,7 @@ import createAxiosInstance from 'client/lib/axios';
 import { AUTH_COOKIE_NAME } from 'shared/constants';
 
 interface Props extends AppProps {
-  authedUser: User;
+  authedUser: User | null;
 }
 
 const App = ({ Component, pageProps, authedUser }: Props) => {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,7 +2,7 @@ import { AppProps } from 'next/app';
 import React from 'react';
 import 'client/styles/globals.css';
 
-import Layout from 'client/components/Layout';
+import Layout from 'client/components/layout/Layout';
 
 const App = ({ Component, pageProps }: AppProps) => {
   return (

--- a/pages/auth-redirect.tsx
+++ b/pages/auth-redirect.tsx
@@ -10,8 +10,8 @@ const AuthRedirect: React.FC = () => {
   const authDispatch = useAuthDispatch();
 
   const useAuthCode = async (code: string) => {
-    await axios.post('/api/auth/login', { code });
-    authDispatch({ type: 'SET_AUTHED', authed: true });
+    const res = await axios.post('/api/auth/login', { code });
+    authDispatch({ type: 'SET_AUTHED_USER', user: res.data.user });
     router.push('/onboarding');
   };
 

--- a/pages/auth-redirect.tsx
+++ b/pages/auth-redirect.tsx
@@ -2,6 +2,7 @@ import { CircularProgress, Container } from '@mui/material';
 import axios from 'axios';
 import { useRouter } from 'next/router';
 import React from 'react';
+
 import { useAuthDispatch } from 'client/contexts/auth';
 
 const AuthRedirect: React.FC = () => {
@@ -10,7 +11,7 @@ const AuthRedirect: React.FC = () => {
 
   const useAuthCode = async (code: string) => {
     await axios.post('/api/auth/login', { code });
-    authDispatch({ type: "SET_AUTHED", authed: true })
+    authDispatch({ type: 'SET_AUTHED', authed: true });
     router.push('/onboarding');
   };
 

--- a/pages/auth-redirect.tsx
+++ b/pages/auth-redirect.tsx
@@ -1,13 +1,16 @@
-import { CircularProgress } from '@mui/material';
+import { CircularProgress, Container } from '@mui/material';
 import axios from 'axios';
 import { useRouter } from 'next/router';
 import React from 'react';
+import { useAuthDispatch } from 'client/contexts/auth';
 
 const AuthRedirect: React.FC = () => {
   const router = useRouter();
+  const authDispatch = useAuthDispatch();
 
   const useAuthCode = async (code: string) => {
     await axios.post('/api/auth/login', { code });
+    authDispatch({ type: "SET_AUTHED", authed: true })
     router.push('/onboarding');
   };
 
@@ -18,7 +21,9 @@ const AuthRedirect: React.FC = () => {
   }, [router.query.code]);
 
   return (
-    <div><CircularProgress /></div>
+    <Container className="mt-6 flex justify-center">
+      <CircularProgress />
+    </Container>
   );
 };
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,10 @@
-import { Box, Button, Container, Typography } from '@mui/material';
+import { Container } from '@mui/material';
 import jwt from 'jsonwebtoken';
 import { NextPage } from 'next';
 import React from 'react';
 import Cookies from 'universal-cookie';
 
 import createAxiosInstance from 'client/lib/axios';
-import { getDiscordOauthUrl } from 'client/lib/oauth';
 import { AUTH_COOKIE_NAME } from 'shared/constants';
 
 interface Props {
@@ -13,33 +12,9 @@ interface Props {
 }
 
 const Index: NextPage<Props> = props => {
-  const [isAuthed, setIsAuthed] = React.useState(props.isAuthed);
-
-  const onLogout = async () => {
-    const axios = createAxiosInstance();
-    await axios.post('/api/auth/logout');
-    setIsAuthed(false);
-  };
-
   return (
     <Container maxWidth="lg" className="flex justify-between pt-4">
-      <Typography variant="h1" className="text-3xl">
-        dev-directory
-      </Typography>
-      <Box className="flex items-center gap-4">
-        <Typography>
-          You are {!isAuthed ? 'not' : ''} logged in
-        </Typography>
-        {isAuthed ? (
-          <Button variant="contained" color="secondary" onClick={onLogout}>
-            Log out
-          </Button>
-        ) : (
-          <Button variant="contained" color="primary" href={getDiscordOauthUrl()}>
-            Log in
-          </Button>
-        )}
-      </Box>
+      this is the home page
     </Container>
   );
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,7 +11,7 @@ interface Props {
   isAuthed: boolean;
 }
 
-const Index: NextPage<Props> = props => {
+const Index: NextPage<Props> = () => {
   return (
     <Container maxWidth="lg" className="flex justify-between pt-4">
       this is the home page

--- a/server/api/auth/auth.test.ts
+++ b/server/api/auth/auth.test.ts
@@ -2,6 +2,7 @@ import { randEmail, randUserName } from '@ngneat/falso';
 import DiscordOauth2 from 'discord-oauth2';
 import { cleanEnv, str } from 'envalid';
 import jwt from 'jsonwebtoken';
+import _ from 'lodash';
 import setCookie, { Cookie } from 'set-cookie-parser';
 
 import * as authLib from 'server/lib/auth';
@@ -39,7 +40,7 @@ describe('auth router', () => {
       expect(res.status).toBe(400);
     });
 
-    it('should create a user, sign a token, and set a cookie', async () => {
+    it('should create a user, sign a token, and set a cookie, and return the user', async () => {
       const id = String(Math.random());
 
       const getInfoSpy = mockDiscord({
@@ -53,6 +54,10 @@ describe('auth router', () => {
 
       expect(res.status).toBe(200);
 
+      const createdUser = await User.findOne({ where: { discord_user_id: id }});
+
+      expect(res.body.user).toEqual(_.pick(createdUser, User.allowedFields));
+
       // ensure the function was called with the code that we sent
       expect(getInfoSpy.mock.calls[0][0] === code);
 
@@ -62,8 +67,6 @@ describe('auth router', () => {
       const cookie = cookies.find(cookie => cookie.name === AUTH_COOKIE_NAME);
 
       const cookiePayload = jwt.decode(cookie.value);
-
-      const createdUser = await User.findOne({ where: { discord_user_id: id }});
 
       // the cookie payload will contain extra things, so we just
       // want to make sure that it contains the same fields as user

--- a/server/api/auth/auth.test.ts
+++ b/server/api/auth/auth.test.ts
@@ -40,7 +40,7 @@ describe('auth router', () => {
       expect(res.status).toBe(400);
     });
 
-    it('should create a user, sign a token, and set a cookie, and return the user', async () => {
+    it('should create a user, sign a token, set a cookie, and return the user', async () => {
       const id = String(Math.random());
 
       const getInfoSpy = mockDiscord({


### PR DESCRIPTION
# Description

Changes:
* Moves the nav/layout-related markup to a separate series of components to render the header and the navbar
* Adds an auth context for keeping track of auth state (currently a simple boolean) using [immer](https://immerjs.github.io/immer/)
  * Loads the authed state globally at the `_app` level
* Dark mode always cuz developers

## Testing

Test manually by going through the login/logout flow.  No hard refreshes should be required for state to update.

Run server tests for updated server routes.
![image](https://user-images.githubusercontent.com/5304277/236667317-7d52d278-c380-48cf-ab10-6d59782290fe.png)


## Type of change

Please remove all except for everything applicable, and then remove this line.

- Other (please specify)

^I'd refer to this as a refactor which didn't feel appropriate under any of the other options.  We should probably add that as an option?

## Screenshots

### Logged out
![image](https://user-images.githubusercontent.com/5304277/236618672-42997d0a-bb85-42b1-80c5-ee0a3f5fddc0.png)

### Logged in
![image](https://user-images.githubusercontent.com/5304277/236618681-2caa5140-f6b3-483c-adc8-aaa990bb6004.png)


# Checklist:

- [x] Changes have new/updated automated tests, if applicable
- [x] Changes have new/updated docs, if applicable
- [x] I have performed a self-review of my own code
- [x] I have added comments on any new, hard-to-understand code
- [x] Changes have been manually tested
- [x] Changes generate no new errors or warnings
