### PR TITLE
Editing User Profile

### DIFF
--- a/client/components/layout/UserForm.tsx
+++ b/client/components/layout/UserForm.tsx
@@ -39,7 +39,7 @@ const UserForm:React.FC<Props> = ({ user, setUser }) => {
     try {
       const userId = user.id;
 
-      const response = await axios.patch(`/api/users/${userId}`, userData);
+      await axios.patch(`/api/users/${userId}`, userData);
       authDispatch({ type: 'SET_AUTHED_USER', user: { ...user, ...userData }});
       setUser({
         ...user,

--- a/client/components/layout/UserForm.tsx
+++ b/client/components/layout/UserForm.tsx
@@ -1,0 +1,87 @@
+import { Button, Container, TextField } from '@mui/material';
+import axios from 'axios';
+import { useState } from 'react';
+
+import { useAuthState, useAuthDispatch } from 'client/contexts/auth';
+
+const UserForm = () => {
+  const { authedUser } = useAuthState();
+  const authDispatch = useAuthDispatch();
+
+  const [userData, setUserData] = useState({
+    bio: authedUser.bio || '',
+    twitter_username: authedUser.twitter_username || '',
+    linkedin_url: authedUser.linkedin_url || '',
+    github_username: authedUser.github_username || '',
+    website: authedUser.website || '',
+  });
+
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target;
+    setUserData(prevState => ({ ...prevState, [name]: value }));
+  };
+
+  const handleSubmit = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    event.preventDefault();
+    if (isLoading) {
+      return;
+    }
+    setIsLoading(true);
+    try {
+      const userId = authedUser.id;
+
+      const response = await axios.patch(`/api/users/${userId}`, userData);
+      authDispatch({ type: 'SET_AUTHED_USER', user: userData });
+      console.log(response.status);
+
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Container maxWidth="sm">
+      <form onSubmit={handleSubmit}>
+        <TextField
+          name="bio"
+          label="Bio"
+          value={userData.bio}
+          onChange={handleChange}
+        />
+        <TextField
+          name="twitter_username"
+          label="Twitter Username"
+          value={userData.twitter_username}
+          onChange={handleChange}
+        />
+        <TextField
+          name="linkedin_url"
+          label="LinkedIn URL"
+          value={userData.linkedin_url}
+          onChange={handleChange}
+        />
+        <TextField
+          name="github_username"
+          label="GitHub Username"
+          value={userData.github_username}
+          onChange={handleChange}
+        />
+        <TextField
+          name="website"
+          label="Website"
+          value={userData.website}
+          onChange={handleChange}
+        />
+        <Button type="submit" variant="contained" color="primary" disabled={isLoading}>
+          {isLoading ? 'Updating...' : 'Update'}
+        </Button>
+      </form>
+    </Container>
+  );
+};
+
+export default UserForm;

--- a/client/components/layout/UserForm.tsx
+++ b/client/components/layout/UserForm.tsx
@@ -62,7 +62,6 @@ const UserForm:React.FC<Props> = ({ user, setUser }) => {
       <form onSubmit={handleSubmit}>
         <Box display="flex" flexDirection="column" gap={2}>
           <TextField
-            id="outlined-multiline-static"
             label="Bio"
             name="bio"
             multiline

--- a/client/components/layout/UserForm.tsx
+++ b/client/components/layout/UserForm.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { useAuthDispatch } from 'client/contexts/auth';
 
 import { UserProfile } from 'server/types/User';
+import { Box } from '@mui/system';
 
 interface Props {
   user: UserProfile;
@@ -60,39 +61,43 @@ const UserForm:React.FC<Props> = ( {user, setUser} ) => {
   return (
     <Container maxWidth="sm">
       <form onSubmit={handleSubmit}>
-        <TextField
-          name="bio"
-          label="Bio"
-          value={userData.bio}
-          onChange={handleChange}
-        />
-        <TextField
-          name="twitter_username"
-          label="Twitter Username"
-          value={userData.twitter_username}
-          onChange={handleChange}
-        />
-        <TextField
-          name="linkedin_url"
-          label="LinkedIn URL"
-          value={userData.linkedin_url}
-          onChange={handleChange}
-        />
-        <TextField
-          name="github_username"
-          label="GitHub Username"
-          value={userData.github_username}
-          onChange={handleChange}
-        />
-        <TextField
-          name="website"
-          label="Website"
-          value={userData.website}
-          onChange={handleChange}
-        />
-        <Button type="submit" variant="contained" color="primary" disabled={isLoading}>
-          {isLoading ? 'Updating...' : 'Update'}
-        </Button>
+        <Box display="flex" flexDirection="column" gap={2}>
+          <TextField
+            id="outlined-multiline-static"
+            label="Bio"
+            multiline
+            rows={4}
+            value={userData.bio}
+            onChange={handleChange}
+          />
+          <TextField
+            name="twitter_username"
+            label="Twitter Username"
+            value={userData.twitter_username}
+            onChange={handleChange}
+          />
+          <TextField
+            name="linkedin_url"
+            label="LinkedIn URL"
+            value={userData.linkedin_url}
+            onChange={handleChange}
+          />
+          <TextField
+            name="github_username"
+            label="GitHub Username"
+            value={userData.github_username}
+            onChange={handleChange}
+          />
+          <TextField
+            name="website"
+            label="Website"
+            value={userData.website}
+            onChange={handleChange}
+          />
+          <Button type="submit" variant="contained" color="primary" disabled={isLoading}>
+            {isLoading ? 'Updating...' : 'Update'}
+          </Button>
+        </Box>
       </form>
     </Container>
   );

--- a/client/components/layout/UserForm.tsx
+++ b/client/components/layout/UserForm.tsx
@@ -12,10 +12,7 @@ interface Props {
   setUser: React.Dispatch<React.SetStateAction<UserProfile>>;
 }
 
-
-//fix edit profile button
 //add testing
-//basic design love
 
 const UserForm:React.FC<Props> = ( {user, setUser} ) => {
   const authDispatch = useAuthDispatch();
@@ -29,6 +26,7 @@ const UserForm:React.FC<Props> = ( {user, setUser} ) => {
   });
 
   const [isLoading, setIsLoading] = useState(false);
+  const [isFormVisible, setIsFormVisible] = useState(true);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;
@@ -45,19 +43,24 @@ const UserForm:React.FC<Props> = ( {user, setUser} ) => {
       const userId = user.id;
 
       const response = await axios.patch(`/api/users/${userId}`, userData);
-      authDispatch({ type: 'SET_AUTHED_USER', user: userData });
+      authDispatch({ type: 'SET_AUTHED_USER', user: { ...user, ...userData }});
       console.log(response.status);
       setUser({
         ...user,
         ...userData,
       })
-
+      setIsFormVisible(false);
     } catch (error) {
       console.error(error);
     } finally {
       setIsLoading(false);
     }
   };
+
+  if (!isFormVisible) {
+    return null;
+  }
+
   return (
     <Container maxWidth="sm">
       <form onSubmit={handleSubmit}>
@@ -65,6 +68,7 @@ const UserForm:React.FC<Props> = ( {user, setUser} ) => {
           <TextField
             id="outlined-multiline-static"
             label="Bio"
+            name="bio"
             multiline
             rows={4}
             value={userData.bio}

--- a/client/components/layout/UserForm.tsx
+++ b/client/components/layout/UserForm.tsx
@@ -1,20 +1,17 @@
 import { Button, Container, TextField } from '@mui/material';
+import { Box } from '@mui/system';
 import axios from 'axios';
 import { useState } from 'react';
 
 import { useAuthDispatch } from 'client/contexts/auth';
-
 import { UserProfile } from 'server/types/User';
-import { Box } from '@mui/system';
 
 interface Props {
   user: UserProfile;
   setUser: React.Dispatch<React.SetStateAction<UserProfile>>;
 }
 
-//add testing
-
-const UserForm:React.FC<Props> = ( {user, setUser} ) => {
+const UserForm:React.FC<Props> = ({ user, setUser }) => {
   const authDispatch = useAuthDispatch();
 
   const [userData, setUserData] = useState({
@@ -33,7 +30,7 @@ const UserForm:React.FC<Props> = ( {user, setUser} ) => {
     setUserData(prevState => ({ ...prevState, [name]: value }));
   };
 
-  const handleSubmit:React.FormEventHandler<HTMLFormElement> = async (event) => {
+  const handleSubmit:React.FormEventHandler<HTMLFormElement> = async event => {
     event.preventDefault();
     if (isLoading) {
       return;
@@ -44,11 +41,10 @@ const UserForm:React.FC<Props> = ( {user, setUser} ) => {
 
       const response = await axios.patch(`/api/users/${userId}`, userData);
       authDispatch({ type: 'SET_AUTHED_USER', user: { ...user, ...userData }});
-      console.log(response.status);
       setUser({
         ...user,
         ...userData,
-      })
+      });
       setIsFormVisible(false);
     } catch (error) {
       console.error(error);

--- a/client/components/layout/UserForm.tsx
+++ b/client/components/layout/UserForm.tsx
@@ -2,18 +2,29 @@ import { Button, Container, TextField } from '@mui/material';
 import axios from 'axios';
 import { useState } from 'react';
 
-import { useAuthState, useAuthDispatch } from 'client/contexts/auth';
+import { useAuthDispatch } from 'client/contexts/auth';
 
-const UserForm = () => {
-  const { authedUser } = useAuthState();
+import { UserProfile } from 'server/types/User';
+
+interface Props {
+  user: UserProfile;
+  setUser: React.Dispatch<React.SetStateAction<UserProfile>>;
+}
+
+
+//fix edit profile button
+//add testing
+//basic design love
+
+const UserForm:React.FC<Props> = ( {user, setUser} ) => {
   const authDispatch = useAuthDispatch();
 
   const [userData, setUserData] = useState({
-    bio: authedUser.bio || '',
-    twitter_username: authedUser.twitter_username || '',
-    linkedin_url: authedUser.linkedin_url || '',
-    github_username: authedUser.github_username || '',
-    website: authedUser.website || '',
+    bio: user.bio || '',
+    twitter_username: user.twitter_username || '',
+    linkedin_url: user.linkedin_url || '',
+    github_username: user.github_username || '',
+    website: user.website || '',
   });
 
   const [isLoading, setIsLoading] = useState(false);
@@ -23,18 +34,22 @@ const UserForm = () => {
     setUserData(prevState => ({ ...prevState, [name]: value }));
   };
 
-  const handleSubmit = async (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleSubmit:React.FormEventHandler<HTMLFormElement> = async (event) => {
     event.preventDefault();
     if (isLoading) {
       return;
     }
     setIsLoading(true);
     try {
-      const userId = authedUser.id;
+      const userId = user.id;
 
       const response = await axios.patch(`/api/users/${userId}`, userData);
       authDispatch({ type: 'SET_AUTHED_USER', user: userData });
       console.log(response.status);
+      setUser({
+        ...user,
+        ...userData,
+      })
 
     } catch (error) {
       console.error(error);
@@ -42,7 +57,6 @@ const UserForm = () => {
       setIsLoading(false);
     }
   };
-
   return (
     <Container maxWidth="sm">
       <form onSubmit={handleSubmit}>

--- a/client/components/layout/UserForm.tsx
+++ b/client/components/layout/UserForm.tsx
@@ -68,6 +68,7 @@ const UserForm:React.FC<Props> = ({ user, setUser }) => {
             rows={4}
             value={userData.bio}
             onChange={handleChange}
+            data-cy="bio-input"
           />
           <TextField
             name="twitter_username"
@@ -93,7 +94,13 @@ const UserForm:React.FC<Props> = ({ user, setUser }) => {
             value={userData.website}
             onChange={handleChange}
           />
-          <Button type="submit" variant="contained" color="primary" disabled={isLoading}>
+          <Button
+            type="submit"
+            variant="contained"
+            color="primary"
+            disabled={isLoading}
+            data-cy="update-button"
+          >
             {isLoading ? 'Updating...' : 'Update'}
           </Button>
         </Box>

--- a/cypress/e2e/editProfile.spec.ts
+++ b/cypress/e2e/editProfile.spec.ts
@@ -3,12 +3,12 @@ import '../support/commands';
 
 describe('Edit profile functions correctly', () => {
   before(() => {
-    cy.truncateDatabase();
     cy.createUsers(10);
   });
 
   beforeEach(() => {
     cy.login(1).reload();
+    cy.createUsers(10);
   });
 
   it('Prevents a user from editing other users profiles', () => {

--- a/cypress/e2e/editProfile.spec.ts
+++ b/cypress/e2e/editProfile.spec.ts
@@ -13,19 +13,19 @@ describe('Edit profile functions correctly', () => {
 
   it('Prevents a user from editing other users profiles', () => {
     cy.visit('http://localhost:3000/profile/2');
-    cy.contains('button', 'Edit Profile').should('not.exist');
+    cy.get('[data-cy="edit-button"]').should('not.exist');
   });
 
   it('Allows a user the ability to edit their profile', () => {
     cy.visit('http://localhost:3000/profile/1');
-    cy.contains('button', 'Edit Profile').should('exist');
+    cy.get('[data-cy="edit-button"]').should('exist');
   });
 
   it('Editing profile works and updates the webpage', () => {
     cy.visit('http://localhost:3000/profile/1');
-    cy.contains('button', 'Edit Profile').click();
-    cy.get('textarea[name=bio]').clear().type('Tim prefers water with cereal');
-    cy.contains('button', 'Update').click();
+    cy.get('[data-cy="edit-button"]').click();
+    cy.get('[data-cy="bio-input"]').clear().type('Tim prefers water with cereal');
+    cy.get('[data-cy="update-button"]').click();
     cy.contains('p', 'Tim prefers water with cereal').should('exist');
   });
 });

--- a/cypress/e2e/editProfile.spec.ts
+++ b/cypress/e2e/editProfile.spec.ts
@@ -1,0 +1,33 @@
+/// <reference types="cypress" />
+import '../support/commands';
+
+describe('Edit profile functions correctly', () => {
+  before(() => {
+    cy.truncateDatabase();
+    cy.createUsers(10);
+  });
+
+  beforeEach(() => {
+    cy.login(1).reload();
+  });
+
+  it('Prevents a user from editing other users profiles', () => {
+    cy.visit('http://localhost:3000/profile/2');
+    cy.contains('button', 'Edit Profile').should('not.exist');
+  });
+
+  it('Allows a user the ability to edit their profile', () => {
+    cy.visit('http://localhost:3000/profile/1');
+    cy.contains('button', 'Edit Profile').should('exist');
+  });
+
+  it('Editing profile works and updates the webpage', () => {
+    cy.visit('http://localhost:3000/profile/1');
+    cy.contains('button', 'Edit Profile').click();
+    cy.get('textarea[name=bio]').clear().type('Tim prefers water with cereal');
+    cy.contains('button', 'Update').click();
+    cy.contains('p', 'Tim prefers water with cereal').should('exist');
+  });
+});
+
+export {};

--- a/pages/profile/[id].tsx
+++ b/pages/profile/[id].tsx
@@ -17,7 +17,7 @@ interface Props {
   statusCode: number;
 }
 
-const ProfilePage: NextPage<Props> = ({ user:userProp, statusCode }) => {
+const ProfilePage: NextPage<Props> = ({ user: userProp, statusCode }) => {
   function possessiveForm(name: string): string {
     return name.endsWith('s') ? `${name}'` : `${name}'s`;
   }
@@ -38,6 +38,8 @@ const ProfilePage: NextPage<Props> = ({ user:userProp, statusCode }) => {
   const handleToggleForm = async () => {
     setIsFormVisible(prev => !prev);
   };
+
+  console.log(authedUser);
 
   return (
     <>

--- a/pages/profile/[id].tsx
+++ b/pages/profile/[id].tsx
@@ -39,8 +39,6 @@ const ProfilePage: NextPage<Props> = ({ user: userProp, statusCode }) => {
     setIsFormVisible(prev => !prev);
   };
 
-  console.log(authedUser);
-
   return (
     <>
       <Container className="flex flex-col gap-4 pt-20 items-center">

--- a/pages/profile/[id].tsx
+++ b/pages/profile/[id].tsx
@@ -52,6 +52,7 @@ const ProfilePage: NextPage<Props> = ({ user: userProp, statusCode }) => {
               color="primary"
               className="text-2xl font-700 text-center"
               onClick={handleToggleForm}
+              data-cy="edit-button"
             >
               Edit Profile
             </Button>

--- a/pages/profile/[id].tsx
+++ b/pages/profile/[id].tsx
@@ -2,11 +2,13 @@ import GitHubIcon from '@mui/icons-material/GitHub';
 import HomeRoundedIcon from '@mui/icons-material/HomeRounded';
 import LinkedInIcon from '@mui/icons-material/LinkedIn';
 import TwitterIcon from '@mui/icons-material/Twitter';
-import { Container, Box, ListItemIcon, ListItemButton, List, Typography } from '@mui/material';
+import { Container, Box, Button, ListItemIcon, ListItemButton, List, Typography } from '@mui/material';
 import { NextPage, NextPageContext } from 'next';
 import ErrorPage from 'next/error';
 import React from 'react';
 
+import UserForm from 'client/components/layout/UserForm';
+import { useAuthState } from 'client/contexts/auth';
 import createAxiosInstance from 'client/lib/axios';
 import { UserProfile } from 'server/types/User';
 
@@ -25,6 +27,16 @@ const ProfilePage: NextPage<Props> = ({ user, statusCode }: Props) => {
     return <ErrorPage statusCode={isErrorCode ? statusCode : 404}/>;
   }
 
+  const { authedUser } = useAuthState();
+
+  const isAuthedUsersProfile = authedUser.id === user.id;
+
+  const [isFormVisible, setIsFormVisible] = React.useState(false);
+
+  const handleToggleForm = async () => {
+    setIsFormVisible(prev => !prev);
+  };
+
   return (
     <>
       <Container className="flex flex-col gap-4 pt-20 items-center">
@@ -32,7 +44,15 @@ const ProfilePage: NextPage<Props> = ({ user, statusCode }: Props) => {
           <Typography variant="h1" className="text-5xl font-700 text-center">
             {possessiveForm(user.discord_name)} Profile
           </Typography>
+          {isAuthedUsersProfile && (
+            <Button variant="contained" color="primary" className="text-2xl font-700 text-center"
+              onClick={handleToggleForm}>
+              Edit Profile
+            </Button>
+          )}
         </Box>
+
+        {isFormVisible && <UserForm/>}
 
         {user.bio && <Typography variant="body1" component="p">{user.bio}</Typography>}
 

--- a/pages/profile/[id].tsx
+++ b/pages/profile/[id].tsx
@@ -17,17 +17,19 @@ interface Props {
   statusCode: number;
 }
 
-const ProfilePage: NextPage<Props> = ({ user, statusCode }: Props) => {
+const ProfilePage: NextPage<Props> = ({ user:userProp, statusCode }) => {
   function possessiveForm(name: string): string {
     return name.endsWith('s') ? `${name}'` : `${name}'s`;
   }
 
   const isErrorCode = statusCode < 200 || statusCode >= 300;
-  if (isErrorCode || !user) {
+  if (isErrorCode || !userProp) {
     return <ErrorPage statusCode={isErrorCode ? statusCode : 404}/>;
   }
 
   const { authedUser } = useAuthState();
+
+  const [user, setUser] = React.useState<UserProfile>(userProp);
 
   const isAuthedUsersProfile = authedUser.id === user.id;
 
@@ -52,7 +54,7 @@ const ProfilePage: NextPage<Props> = ({ user, statusCode }: Props) => {
           )}
         </Box>
 
-        {isFormVisible && <UserForm/>}
+        {isFormVisible && <UserForm setUser={setUser} user={user}/>}
 
         {user.bio && <Typography variant="body1" component="p">{user.bio}</Typography>}
 

--- a/pages/profile/[id].tsx
+++ b/pages/profile/[id].tsx
@@ -47,8 +47,12 @@ const ProfilePage: NextPage<Props> = ({ user: userProp, statusCode }) => {
             {possessiveForm(user.discord_name)} Profile
           </Typography>
           {isAuthedUsersProfile && (
-            <Button variant="contained" color="primary" className="text-2xl font-700 text-center"
-              onClick={handleToggleForm}>
+            <Button
+              variant="contained"
+              color="primary"
+              className="text-2xl font-700 text-center"
+              onClick={handleToggleForm}
+            >
               Edit Profile
             </Button>
           )}


### PR DESCRIPTION
Closes #12

# Description

Adds an edit profile button for owner's profile and live updating of 

## Testing

Execute `npm run cypress:open` test was added to `editProfile` in `e2e` testing.

One thing I noticed with testing is this impacts the local dev environment outside of cypress. Specifically with the overwriting of users in the DB. 

## Type of change

Please remove all except for everything applicable, and then remove this line.

- New feature (non-breaking change which adds functionality)

## Screenshots

<img width="671" alt="Screenshot 2023-06-05 at 5 39 42 PM" src="https://github.com/timmyichen/dev-directory/assets/75268174/6db6bb64-8442-4dd5-9b7d-571817ba039d">

Please include any screenshots if there are visual changes.

# Checklist:

- [x] Changes have new/updated automated tests, if applicable
- [x] Changes have new/updated docs, if applicable
- [x] I have performed a self-review of my own code
- [x] I have added comments on any new, hard-to-understand code
- [x] Changes have been manually tested
- [x] Changes generate no new errors or warnings
