### PR TITLE
adding cypress to npm run test

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "rm -rf dist && ttsc && next build",
+    "cypress": "cypress run",
     "cypress:open": "cypress open",
     "dev:server": "cross-env NODE_ENV=development npm run ts:exec server/index.ts",
     "dev": "nodemon",
@@ -21,7 +22,7 @@
     "start": "node dist/server/index",
     "test:server": "npm run jest -- ./server",
     "test:watch": "npm run jest -- --watch",
-    "test": "npm run jest",
+    "test": "npm run jest && npm run cypress",
     "ts:exec": "ts-node -r tsconfig-paths/register --project ./tsconfig.json --transpile-only",
     "ts:check": "npx tsc --noEmit"
   },


### PR DESCRIPTION
Closes #issue-number-here (replace with issue number)

# Description

Add's cypress test directly into `npm run test`

## Testing

I did encounter an error with testing. After confering with @MainlyColors he assured me this was a bug that happens periodically, and we hope this does not occur outside of random occurrences. 
<img width="667" alt="Screenshot 2023-06-08 at 1 38 42 PM" src="https://github.com/timmyichen/dev-directory/assets/75268174/64e3ccfc-7116-4c50-a7ac-33339beae97d">


## Type of change

Please remove all except for everything applicable, and then remove this line.

- Change to documentation/GitHub flows/CICD

## Screenshots

Included in testing

# Checklist:

- [x] Changes have new/updated automated tests, if applicable
- [x] Changes have new/updated docs, if applicable
- [x] I have performed a self-review of my own code
- [x] I have added comments on any new, hard-to-understand code
- [x] Changes have been manually tested
- [ ] Changes generate no new errors or warnings
