### PR TITLE
fix flags migration

### DIFF
--- a/server/migrations/20230611233941-create-flags-table.js
+++ b/server/migrations/20230611233941-create-flags-table.js
@@ -3,7 +3,7 @@
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up(queryInterface, Sequelize) {
-    queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.sequelize.transaction(async transaction => {
       await queryInterface.createTable('flags', {
         id: {
           type: Sequelize.INTEGER,


### PR DESCRIPTION
# Description

The migration that added the `flags` table wasn't awaiting the transaction that contained all the commands to create the table and the index. The issue wasn't reproducible locally for some reason, but the hypothesis is that when Heroku is deploying the application, as soon as the migration runs, it kills the process, which prevents the transaction from finishing.  Awaiting the transaction fixed the issue.

**NOTE** that in general, once deployed, you _cannot_ make changes to a migration file and have its changes re-applied.  You'd normally have to create a new migration entirely.  This fix worked and is deployed to staging only because I connected to the staging database and made it "forget" that it ran this migration, allowing it to be re-run on the next deploy.  But this is not common (nor is it really recommended, and definitely shouldn't be done in production), but since this is staging and we're pre-launch, it's fine?

## Testing

This is already deployed to staging; logging in on staging now works as expected

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please include any screenshots if there are visual changes.

# Checklist:

- [x] Changes have new/updated automated tests, if applicable
- [x] Changes have new/updated docs, if applicable
- [x] I have performed a self-review of my own code
- [x] I have added comments on any new, hard-to-understand code
- [x] Changes have been manually tested
- [x] Changes generate no new errors or warnings
